### PR TITLE
Update spec3.json

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -32143,7 +32143,8 @@
             "required": false,
             "schema": {
               "title": "Page[Size]",
-              "exclusiveMinimum": 0,
+              "exclusiveMinimum": true,
+              "minimum": 0,
               "type": "integer",
               "default": 100,
               "lte": 1000


### PR DESCRIPTION
Spec is not valid for v3
`error decoding spec: unsupported field in JSON schema: 'exclusiveMinimum'`