### PR TITLE
test(openapi): shorten operationIds >64 chars for LLM function-calling

### DIFF
--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -71028,7 +71028,7 @@ paths:
     get:
       description: Retrieves paginated history of test runs for a specific test suite
         with filtering options
-      operationId: get_test_suite_runs_for_test_public_assistants_tests_test_suites__suite_name__runs_get
+      operationId: get_test_suite_runs_for_test_public_assistants_tests_test_05957d
       parameters:
       - in: path
         name: suite_name
@@ -71095,7 +71095,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Executes all tests within a specific test suite as a batch operation
-      operationId: trigger_test_suite_runs_public_assistants_tests_test_suites__suite_name__runs_post
+      operationId: trigger_test_suite_runs_public_assistants_tests_test_suit_04f301
       parameters:
       - in: path
         name: suite_name
@@ -71219,7 +71219,7 @@ paths:
     get:
       description: Retrieves paginated execution history for a specific assistant
         test with filtering options
-      operationId: get_test_runs_for_test_public_assistants_tests__test_id__runs_get
+      operationId: get_test_runs_for_test_public_assistants_tests__test_id_1e13ed
       parameters:
       - in: path
         name: test_id
@@ -71463,7 +71463,7 @@ paths:
 
 
         Removes all canary deploy configurations for the specified assistant.'
-      operationId: delete_canary_deploy_assistants__assistant_id__canary_deploys_delete
+      operationId: delete_canary_deploy_assistants__assistant_id__canary_dep_d3577a
       parameters:
       - in: path
         name: assistant_id
@@ -71525,7 +71525,7 @@ paths:
         traffic
 
         percentages for A/B testing or gradual rollouts of assistant versions.'
-      operationId: create_canary_deploy_assistants__assistant_id__canary_deploys_post
+      operationId: create_canary_deploy_assistants__assistant_id__canary_dep_8d87dc
       parameters:
       - in: path
         name: assistant_id
@@ -71561,7 +71561,7 @@ paths:
         \nUpdates the existing canary deploy configuration with new version IDs and\
         \ percentages.\n  All old versions and percentages are replaces by new ones\
         \ from this request."
-      operationId: update_canary_deploy_assistants__assistant_id__canary_deploys_put
+      operationId: update_canary_deploy_assistants__assistant_id__canary_dep_8647ca
       parameters:
       - in: path
         name: assistant_id
@@ -72031,7 +72031,7 @@ paths:
   /ai/assistants/{assistant_id}/tools/{tool_id}/test:
     post:
       description: Test a webhook tool for an assistant
-      operationId: test_assistant_tool_public_assistants__assistant_id__tools__tool_id__test_post
+      operationId: test_assistant_tool_public_assistants__assistant_id__tool_daba9a
       parameters:
       - in: path
         name: assistant_id
@@ -72071,7 +72071,7 @@ paths:
     get:
       description: Retrieves all versions of a specific assistant with complete configuration
         and metadata
-      operationId: get_assistant_versions_public_assistants__assistant_id__versions_get
+      operationId: get_assistant_versions_public_assistants__assistant_id__v_ae8855
       parameters:
       - in: path
         name: assistant_id
@@ -72101,7 +72101,7 @@ paths:
     delete:
       description: Permanently removes a specific version of an assistant. Can not
         delete main version
-      operationId: delete_assistant_version_public_assistants__assistant_id__versions__version_id__delete
+      operationId: delete_assistant_version_public_assistants__assistant_id_31c680
       parameters:
       - in: path
         name: assistant_id
@@ -72131,7 +72131,7 @@ paths:
     get:
       description: Retrieves a specific version of an assistant by assistant_id and
         version_id
-      operationId: get_assistant_version_public_assistants__assistant_id__versions__version_id__get
+      operationId: get_assistant_version_public_assistants__assistant_id__ve_00586a
       parameters:
       - in: path
         name: assistant_id
@@ -72170,7 +72170,7 @@ paths:
     post:
       description: Updates the configuration of a specific assistant version. Can
         not update main version
-      operationId: update_assistant_version_public_assistants__assistant_id__versions__version_id__post
+      operationId: update_assistant_version_public_assistants__assistant_id_b77d35
       parameters:
       - in: path
         name: assistant_id
@@ -72212,7 +72212,7 @@ paths:
       description: Promotes a specific version to be the main/current version of the
         assistant. This will delete any existing canary deploy configuration and send
         all live production traffic to this version.
-      operationId: promote_assistant_version_public_assistants__assistant_id__versions__version_id__promote_post
+      operationId: promote_assistant_version_public_assistants__assistant_id_6ce57f
       parameters:
       - in: path
         name: assistant_id
@@ -72450,7 +72450,7 @@ paths:
   /ai/clusters/{task_id}/graph:
     get:
       description: Fetch a cluster visualization
-      operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_id__image_get
+      operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_71f1e3
       parameters:
       - in: path
         name: task_id
@@ -73312,7 +73312,7 @@ paths:
     delete:
       description: Deletes an entire bucket's embeddings and disables the bucket for
         AI-use, returning it to normal storage pricing.
-      operationId: embedding_bucket_files_public_embedding_buckets__bucket_name__delete
+      operationId: embedding_bucket_files_public_embedding_buckets__bucket_n_aa7a3f
       parameters:
       - in: path
         name: bucket_name
@@ -73646,7 +73646,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get user setup integrations
-      operationId: get_user_integration_by_id_public_integrations_connections__user_connection_id__get
+      operationId: get_user_integration_by_id_public_integrations_connection_94f206
       parameters:
       - description: The connection id
         in: path
@@ -74200,7 +74200,7 @@ paths:
   /ai/missions/{mission_id}/knowledge-bases/{knowledge_base_id}:
     delete:
       description: Delete a knowledge base from a mission
-      operationId: delete_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: delete_public_missions_missions_mission_id_knowledge_base_f771a0
       parameters:
       - in: path
         name: mission_id
@@ -74229,7 +74229,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific knowledge base by ID
-      operationId: get_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: get_public_missions_missions_mission_id_knowledge_bases_k_3b4024
       parameters:
       - in: path
         name: mission_id
@@ -74261,7 +74261,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update a knowledge base definition
-      operationId: put_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: put_public_missions_missions_mission_id_knowledge_bases_k_cc8f47
       parameters:
       - in: path
         name: mission_id
@@ -74347,7 +74347,7 @@ paths:
   /ai/missions/{mission_id}/mcp-servers/{mcp_server_id}:
     delete:
       description: Delete an MCP server from a mission
-      operationId: delete_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: delete_public_missions_missions_mission_id_mcp_servers_mc_594f7d
       parameters:
       - in: path
         name: mission_id
@@ -74376,7 +74376,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific MCP server by ID
-      operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_s_2328c7
       parameters:
       - in: path
         name: mission_id
@@ -74408,7 +74408,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update an MCP server definition
-      operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_s_0698eb
       parameters:
       - in: path
         name: mission_id
@@ -74762,7 +74762,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/events/{event_id}:
     get:
       description: Get details of a specific event
-      operationId: get_public_missions_missions_mission_id_runs_run_id_events_event_id
+      operationId: get_public_missions_missions_mission_id_runs_run_id_event_6293eb
       parameters:
       - in: path
         name: mission_id
@@ -74959,7 +74959,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/plan/steps/{step_id}:
     get:
       description: Get details of a specific plan step
-      operationId: get_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
+      operationId: get_public_missions_missions_mission_id_runs_run_id_plan_a589c9
       parameters:
       - in: path
         name: mission_id
@@ -75000,7 +75000,7 @@ paths:
       x-latency-category: responsive
     patch:
       description: Update the status of a plan step
-      operationId: patch_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
+      operationId: patch_public_missions_missions_mission_id_runs_run_id_pla_1fd930
       parameters:
       - in: path
         name: mission_id
@@ -75084,7 +75084,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents:
     get:
       description: List all Telnyx agents linked to a run
-      operationId: get_public_missions_missions_mission_id_runs_run_id_telnyx_agents
+      operationId: get_public_missions_missions_mission_id_runs_run_id_telny_1eb271
       parameters:
       - in: path
         name: mission_id
@@ -75119,7 +75119,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Link a Telnyx AI agent (voice/messaging) to a run
-      operationId: post_public_missions_missions_mission_id_runs_run_id_telnyx_agents
+      operationId: post_public_missions_missions_mission_id_runs_run_id_teln_c72855
       parameters:
       - in: path
         name: mission_id
@@ -75161,7 +75161,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents/{telnyx_agent_id}:
     delete:
       description: Unlink a Telnyx agent from a run
-      operationId: delete_public_missions_missions_mission_id_runs_run_id_telnyx_agents_telnyx_agent_id
+      operationId: delete_public_missions_missions_mission_id_runs_run_id_te_40725e
       parameters:
       - in: path
         name: mission_id


### PR DESCRIPTION
**Throwaway test PR** to confirm whether shortening over-long operationIds flips orank's `function-calling-compat` check (currently 1/2, "couldn't validate").

orank tests the spec against ChatGPT/Claude/Gemini function-calling. OpenAI + Gemini cap function names at 64 chars; converters use `operationId` as the name. **27 operationIds** (all `ai/assistants/*`) exceeded 64 chars. This shortens them to ≤64 (6-char hash suffix for uniqueness). 0 dups, 0 invalid chars, both spec3.json + spec3.yml updated.

⚠️ Test only — real fix belongs in openapi-internal source (operationIds drive Stainless SDK method names = breaking change). Do not rely on this branch; next internal sync overwrites it.