### PR TITLE
Revert #195 and #196 (LLM function-calling experiments)

### DIFF
--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -71070,7 +71070,7 @@ paths:
     get:
       description: Retrieves paginated history of test runs for a specific test suite
         with filtering options
-      operationId: get_test_suite_runs_for_test_public_assistants_tests_test_05957d
+      operationId: get_test_suite_runs_for_test_public_assistants_tests_test_suites__suite_name__runs_get
       parameters:
       - description: Name of the suite.
         in: path
@@ -71138,7 +71138,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Executes all tests within a specific test suite as a batch operation
-      operationId: trigger_test_suite_runs_public_assistants_tests_test_suit_04f301
+      operationId: trigger_test_suite_runs_public_assistants_tests_test_suites__suite_name__runs_post
       parameters:
       - description: Name of the suite.
         in: path
@@ -71266,7 +71266,7 @@ paths:
     get:
       description: Retrieves paginated execution history for a specific assistant
         test with filtering options
-      operationId: get_test_runs_for_test_public_assistants_tests__test_id_1e13ed
+      operationId: get_test_runs_for_test_public_assistants_tests__test_id__runs_get
       parameters:
       - description: Unique identifier of the test.
         in: path
@@ -71521,7 +71521,7 @@ paths:
 
 
         Removes all canary deploy configurations for the specified assistant.'
-      operationId: delete_canary_deploy_assistants__assistant_id__canary_dep_d3577a
+      operationId: delete_canary_deploy_assistants__assistant_id__canary_deploys_delete
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -71585,7 +71585,7 @@ paths:
         traffic
 
         percentages for A/B testing or gradual rollouts of assistant versions.'
-      operationId: create_canary_deploy_assistants__assistant_id__canary_dep_8d87dc
+      operationId: create_canary_deploy_assistants__assistant_id__canary_deploys_post
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -71622,7 +71622,7 @@ paths:
         \nUpdates the existing canary deploy configuration with new version IDs and\
         \ percentages.\n  All old versions and percentages are replaces by new ones\
         \ from this request."
-      operationId: update_canary_deploy_assistants__assistant_id__canary_dep_8647ca
+      operationId: update_canary_deploy_assistants__assistant_id__canary_deploys_put
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72113,7 +72113,7 @@ paths:
   /ai/assistants/{assistant_id}/tools/{tool_id}/test:
     post:
       description: Test a webhook tool for an assistant
-      operationId: test_assistant_tool_public_assistants__assistant_id__tool_daba9a
+      operationId: test_assistant_tool_public_assistants__assistant_id__tools__tool_id__test_post
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72155,7 +72155,7 @@ paths:
     get:
       description: Retrieves all versions of a specific assistant with complete configuration
         and metadata
-      operationId: get_assistant_versions_public_assistants__assistant_id__v_ae8855
+      operationId: get_assistant_versions_public_assistants__assistant_id__versions_get
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72186,7 +72186,7 @@ paths:
     delete:
       description: Permanently removes a specific version of an assistant. Can not
         delete main version
-      operationId: delete_assistant_version_public_assistants__assistant_id_31c680
+      operationId: delete_assistant_version_public_assistants__assistant_id__versions__version_id__delete
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72218,7 +72218,7 @@ paths:
     get:
       description: Retrieves a specific version of an assistant by assistant_id and
         version_id
-      operationId: get_assistant_version_public_assistants__assistant_id__ve_00586a
+      operationId: get_assistant_version_public_assistants__assistant_id__versions__version_id__get
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72260,7 +72260,7 @@ paths:
     post:
       description: Updates the configuration of a specific assistant version. Can
         not update main version
-      operationId: update_assistant_version_public_assistants__assistant_id_b77d35
+      operationId: update_assistant_version_public_assistants__assistant_id__versions__version_id__post
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72304,7 +72304,7 @@ paths:
       description: Promotes a specific version to be the main/current version of the
         assistant. This will delete any existing canary deploy configuration and send
         all live production traffic to this version.
-      operationId: promote_assistant_version_public_assistants__assistant_id_6ce57f
+      operationId: promote_assistant_version_public_assistants__assistant_id__versions__version_id__promote_post
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72546,7 +72546,7 @@ paths:
   /ai/clusters/{task_id}/graph:
     get:
       description: Fetch a cluster visualization
-      operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_71f1e3
+      operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_id__image_get
       parameters:
       - description: Unique identifier of the task.
         in: path
@@ -73412,7 +73412,7 @@ paths:
     delete:
       description: Deletes an entire bucket's embeddings and disables the bucket for
         AI-use, returning it to normal storage pricing.
-      operationId: embedding_bucket_files_public_embedding_buckets__bucket_n_aa7a3f
+      operationId: embedding_bucket_files_public_embedding_buckets__bucket_name__delete
       parameters:
       - description: Name of the bucket.
         in: path
@@ -73751,7 +73751,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get user setup integrations
-      operationId: get_user_integration_by_id_public_integrations_connection_94f206
+      operationId: get_user_integration_by_id_public_integrations_connections__user_connection_id__get
       parameters:
       - description: The connection id
         in: path
@@ -74320,7 +74320,7 @@ paths:
   /ai/missions/{mission_id}/knowledge-bases/{knowledge_base_id}:
     delete:
       description: Delete a knowledge base from a mission
-      operationId: delete_public_missions_missions_mission_id_knowledge_base_f771a0
+      operationId: delete_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74351,7 +74351,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific knowledge base by ID
-      operationId: get_public_missions_missions_mission_id_knowledge_bases_k_3b4024
+      operationId: get_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74385,7 +74385,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update a knowledge base definition
-      operationId: put_public_missions_missions_mission_id_knowledge_bases_k_cc8f47
+      operationId: put_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74475,7 +74475,7 @@ paths:
   /ai/missions/{mission_id}/mcp-servers/{mcp_server_id}:
     delete:
       description: Delete an MCP server from a mission
-      operationId: delete_public_missions_missions_mission_id_mcp_servers_mc_594f7d
+      operationId: delete_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74506,7 +74506,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific MCP server by ID
-      operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_s_2328c7
+      operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74540,7 +74540,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update an MCP server definition
-      operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_s_0698eb
+      operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74912,7 +74912,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/events/{event_id}:
     get:
       description: Get details of a specific event
-      operationId: get_public_missions_missions_mission_id_runs_run_id_event_6293eb
+      operationId: get_public_missions_missions_mission_id_runs_run_id_events_event_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75120,7 +75120,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/plan/steps/{step_id}:
     get:
       description: Get details of a specific plan step
-      operationId: get_public_missions_missions_mission_id_runs_run_id_plan_a589c9
+      operationId: get_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75164,7 +75164,7 @@ paths:
       x-latency-category: responsive
     patch:
       description: Update the status of a plan step
-      operationId: patch_public_missions_missions_mission_id_runs_run_id_pla_1fd930
+      operationId: patch_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75253,7 +75253,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents:
     get:
       description: List all Telnyx agents linked to a run
-      operationId: get_public_missions_missions_mission_id_runs_run_id_telny_1eb271
+      operationId: get_public_missions_missions_mission_id_runs_run_id_telnyx_agents
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75290,7 +75290,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Link a Telnyx AI agent (voice/messaging) to a run
-      operationId: post_public_missions_missions_mission_id_runs_run_id_teln_c72855
+      operationId: post_public_missions_missions_mission_id_runs_run_id_telnyx_agents
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75334,7 +75334,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents/{telnyx_agent_id}:
     delete:
       description: Unlink a Telnyx agent from a run
-      operationId: delete_public_missions_missions_mission_id_runs_run_id_te_40725e
+      operationId: delete_public_missions_missions_mission_id_runs_run_id_telnyx_agents_telnyx_agent_id
       parameters:
       - description: Unique identifier of the mission.
         in: path

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -3601,12 +3601,78 @@ components:
           schema:
             $ref: '#/components/schemas/10dlc_Errors'
       description: Generic response error
+    ActionSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                properties:
+                  result:
+                    example: ok
+                    type: string
+                type: object
+            type: object
+      description: Success Action Response
+    ActiveCallsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ActiveCall'
+                type: array
+              meta:
+                $ref: '#/components/schemas/CursorPaginationMeta'
+            title: Active Calls Response
+            type: object
+      description: Successful response with list of details about active calls.
+    AddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Address'
+            type: object
+      description: Successful response
+    AdvancedOrderResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AdvancedOrder'
+      description: An Advanced Order Response
+    AlphanumericSenderIdResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/AlphanumericSenderId'
+            type: object
+      description: Successful response with a single alphanumeric sender ID.
+    AuditLogListResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuditLogList'
+      description: A list of audit log entries.
     AuditLogsGenericErrorResponse:
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/AuditLogsErrors'
       description: Unexpected error.
+    AutoRechargePrefResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/AutoRechargePref'
+            type: object
+      description: Successful response
     BadRequestErrorResponse:
       content:
         application/json:
@@ -3652,12 +3718,904 @@ components:
       description: 'Bad request. The request was invalid or cannot be served. Common
         causes include: audio file download failures, attempting to delete non-empty
         queues, invalid characters in the request, or character encoding errors.'
+    BlackBoxTestResultsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/BlackBoxTestResultSet'
+                type: array
+            type: object
+      description: A list of black box test results.
+    BulkDeleteRoomRecordingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                properties:
+                  room_recordings:
+                    description: Amount of room recordings affected
+                    example: 5
+                    type: integer
+                type: object
+            title: Bulk Room Recordings Delete Response
+            type: object
+      description: Successful response for Bulk Delete Room recordings requests
+    BulkMessagingSettingsUpdatePhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/BulkMessagingSettingsUpdatePhoneNumbers'
+            title: Retrieve bulk update messaging settings Response
+            type: object
+      description: Successful response with details about messaging bulk update phone
+        numbers.
+    BulkSIMCardActionCollectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/BulkSIMCardActionDetailed'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    BulkSIMCardActionDetailedResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/BulkSIMCardActionDetailed'
+            type: object
+      description: Successful Response
+    BulkSIMCardActionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/BulkSIMCardAction'
+            type: object
+      description: Successful Response
+    CallControlApplicationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallControlApplication'
+            title: Call Control Application Response
+            type: object
+      description: Successful response with details about a call control application.
+    CallControlCommandResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallControlCommandResult'
+            title: Call Control Command Response
+            type: object
+      description: Successful response upon making a call control command.
+    CallControlCommandResponseWithConversationId:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallControlCommandResultWithConversationId'
+            title: Call Control Command Response With Conversation ID
+            type: object
+      description: Successful response upon making a call control command that includes
+        conversation_id.
+    CallControlCommandResponseWithConversationRelayId:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallControlCommandResultWithConversationRelayId'
+            title: Call Control Command Response With Conversation Relay ID
+            type: object
+      description: Successful response upon starting Conversation Relay.
+    CallControlCommandResponseWithRecordingId:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallControlCommandResultWithRecordingId'
+            title: Call Control Command Response With Recording ID
+            type: object
+      description: Successful response upon making a call control command that includes
+        recording_id.
+    CancelFaxResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                result: ok
+            properties:
+              data:
+                properties:
+                  result:
+                    example: ok
+                    type: string
+                type: object
+            title: Successful response upon accepting cancel fax command
+            type: object
+      description: Successful response upon accepting cancel fax command
+    CancelPortingOrderResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                activation_settings:
+                  activation_status: null
+                  fast_port_eligible: true
+                  foc_datetime_actual: null
+                  foc_datetime_requested: '2022-04-08T15:00:00Z'
+                created_at: '2022-03-24T14:22:28Z'
+                customer_group_reference: Group-789
+                customer_reference: Test1234
+                description: FP Telnyx
+                documents:
+                  invoice: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
+                  loa: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
+                end_user:
+                  admin:
+                    account_number: 123abc
+                    auth_person_name: Porter McPortersen II
+                    billing_phone_number: '+13035551234'
+                    business_identifier: abc123
+                    entity_name: Porter McPortersen
+                    pin_passcode: '1234'
+                    tax_identifier: 1234abcd
+                  location:
+                    administrative_area: TX
+                    country_code: US
+                    extended_address: 14th Floor
+                    locality: Austin
+                    postal_code: '78701'
+                    street_address: 600 Congress Avenue
+                id: eef10fb8-f3df-4c67-97c5-e18179723222
+                misc:
+                  new_billing_phone_number: null
+                  remaining_numbers_action: null
+                  type: full
+                old_service_provider_ocn: Unreal Communications
+                parent_support_key: pr_4bec1a
+                phone_number_configuration:
+                  billing_group_id: null
+                  connection_id: '1752379429071357070'
+                  emergency_address_id: null
+                  messaging_profile_id: null
+                  tags: []
+                phone_number_type: local
+                porting_phone_numbers_count: 1
+                record_type: porting_order
+                requirements: []
+                requirements_met: true
+                status:
+                  details: []
+                  value: cancel-pending
+                support_key: sr_10b316
+                updated_at: '2022-03-24T16:43:35Z'
+                user_feedback:
+                  user_comment: null
+                  user_rating: null
+                user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
+                webhook_url: https://example.com/porting_webhooks
+              meta:
+                phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrder'
+              meta:
+                properties:
+                  phone_numbers_url:
+                    description: Link to list all phone numbers
+                    type: string
+                type: object
+            type: object
+      description: Successful response
+    CommentResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                allOf:
+                - $ref: '#/components/schemas/Comment'
+                - type: object
+            type: object
+      description: A Comment Response
+    ConferenceCommandResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ConferenceCommandResult'
+            title: Conference Command Response
+            type: object
+      description: Successful response upon making a conference command.
+    ConferenceResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Conference'
+            title: Conference Response
+            type: object
+      description: Successful response with details about a conference.
+    ConfirmPortingOrderResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                activation_settings:
+                  activation_status: null
+                  fast_port_eligible: true
+                  foc_datetime_actual: null
+                  foc_datetime_requested: '2022-04-08T15:00:00Z'
+                created_at: '2022-03-24T14:22:28Z'
+                customer_group_reference: Group-789
+                customer_reference: Test1234
+                description: FP Telnyx
+                documents:
+                  invoice: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
+                  loa: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
+                end_user:
+                  admin:
+                    account_number: 123abc
+                    auth_person_name: Porter McPortersen II
+                    billing_phone_number: '+13035551234'
+                    business_identifier: abc123
+                    entity_name: Porter McPortersen
+                    pin_passcode: '1234'
+                    tax_identifier: 1234abcd
+                  location:
+                    administrative_area: TX
+                    country_code: US
+                    extended_address: 14th Floor
+                    locality: Austin
+                    postal_code: '78701'
+                    street_address: 600 Congress Avenue
+                id: eef10fb8-f3df-4c67-97c5-e18179723222
+                messaging:
+                  enable_messaging: false
+                  messaging_capable: true
+                  messaging_port_completed: false
+                  messaging_port_status: not_applicable
+                misc:
+                  new_billing_phone_number: null
+                  remaining_numbers_action: null
+                  type: full
+                old_service_provider_ocn: Unreal Communications
+                parent_support_key: pr_4bec1a
+                phone_number_configuration:
+                  billing_group_id: null
+                  connection_id: '1752379429071357070'
+                  emergency_address_id: null
+                  messaging_profile_id: null
+                  tags: []
+                phone_number_type: local
+                porting_phone_numbers_count: 1
+                record_type: porting_order
+                requirements: []
+                requirements_met: true
+                status:
+                  details: []
+                  value: in-process
+                support_key: sr_10b316
+                updated_at: '2022-03-24T16:42:43Z'
+                user_feedback:
+                  user_comment: null
+                  user_rating: null
+                user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
+                webhook_url: https://example.com/porting_webhooks
+              meta:
+                phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrder'
+              meta:
+                properties:
+                  phone_numbers_url:
+                    description: Link to list all phone numbers
+                    type: string
+                type: object
+            type: object
+      description: Successful response
     ConflictErrorResponse:
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Errors'
       description: Resource conflict or in use
+    ConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Connection'
+            title: Connection Response
+            type: object
+      description: Successful response with details about a connection.
+    CountryCoverageResponse:
+      content:
+        application/json:
+          examples:
+            example-1:
+              value:
+                data:
+                  Afghanistan:
+                    code: AF
+                    features: []
+                    international_sms: false
+                    inventory_coverage: false
+                    local: {}
+                    mobile: {}
+                    national: {}
+                    numbers: false
+                    p2p: false
+                    phone_number_type: []
+                    quickship: false
+                    region: null
+                    reservable: false
+                    toll_free: {}
+                  Aland Islands:
+                    code: AX
+                    features: []
+                    international_sms: false
+                    inventory_coverage: false
+                    local: {}
+                    mobile: {}
+                    national: {}
+                    numbers: false
+                    p2p: false
+                    phone_number_type: []
+                    quickship: false
+                    region: null
+                    reservable: false
+                    toll_free: {}
+                  Albania:
+                    code: AL
+                    features:
+                    - voice
+                    - fax
+                    international_sms: false
+                    inventory_coverage: false
+                    local:
+                      features:
+                      - fax
+                      - voice
+                      full_pstn_replacement: false
+                      international_sms: false
+                      p2p: false
+                      quickship: false
+                      reservable: false
+                    mobile: {}
+                    national: {}
+                    numbers: true
+                    p2p: false
+                    phone_number_type:
+                    - local
+                    - toll_free
+                    quickship: false
+                    region: EMEA
+                    reservable: false
+                    shared_cost: {}
+                    toll_free:
+                      features:
+                      - fax
+                      - voice
+                      full_pstn_replacement: false
+                      international_sms: false
+                      p2p: false
+                      quickship: false
+                      reservable: false
+                  Algeria:
+                    code: DZ
+                    features: []
+                    international_sms: false
+                    inventory_coverage: false
+                    local: {}
+                    mobile: {}
+                    national: {}
+                    numbers: false
+                    p2p: false
+                    phone_number_type: []
+                    quickship: false
+                    region: null
+                    reservable: false
+                    toll_free: {}
+          schema:
+            properties:
+              data:
+                additionalProperties:
+                  $ref: '#/components/schemas/CountryCoverage'
+                type: object
+            type: object
+      description: Response for country coverage
+    CreateCustomerServiceRecord:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                created_at: '2023-01-01T00:00:00Z'
+                error_message: null
+                id: db7cebdb-21a8-4e89-8f51-e03ba6b799bb
+                phone_number: '+2003271000'
+                result: null
+                status: pending
+                updated_at: '2023-01-01T00:00:00Z'
+                webhook_url: https://example.com/webhook
+            properties:
+              data:
+                $ref: '#/components/schemas/CustomerServiceRecord'
+            type: object
+      description: Successful Response
+    CreatePortOutSupportingDocumentsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortOutSupportingDocument'
+                type: array
+            type: object
+      description: Portout Supporting Documents
+    CreatePortingAdditionalDocuments:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+              - created_at: '2023-06-01T10:00:00.00000Z'
+                document_id: 40bc547a-7f96-4cd5-926a-da4842671e88
+                document_type: loa
+                id: 2acd1061-33cb-49b8-8014-beb6dc3fedbf
+                porting_order_id: 9d7b3b8e-4e67-4837-9c44-d110cd2c82a1
+                record_type: porting_additional_document
+                updated_at: '2023-06-01T10:00:00.00000Z'
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingAdditionalDocument'
+                type: array
+            type: object
+      description: Successful response
+    CreatePortingLOAConfiguration:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingLOAConfiguration'
+            type: object
+      description: Successful response
+    CreatePortingPhoneNumberConfigurations:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingPhoneNumberConfiguration'
+                type: array
+            type: object
+      description: Successful response
+    CreatePortingReport:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingReport'
+            type: object
+      description: Successful response
+    CreatePortoutReport:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortoutReport'
+            type: object
+      description: Successful response
+    CreatePrivateWirelessGatewayResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                assigned_resources:
+                - count: 1
+                  record_type: sim_card_group
+                created_at: '2018-02-02T22:25:27.521Z'
+                id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
+                ip_range: 100.64.1.0/24
+                name: My private wireless gateway
+                network_id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
+                record_type: private_wireless_gateway
+                region_code: dc2
+                status:
+                  error_code: null
+                  error_description: null
+                  value: provisioning
+                updated_at: '2018-02-02T22:25:27.521Z'
+            properties:
+              data:
+                $ref: '#/components/schemas/PrivateWirelessGateway'
+            type: object
+      description: Successful Response
+    CreateRoomClientTokenResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                example:
+                  refresh_token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDkzNzA1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6ImQ3OWJlMzhjLWFkNTQtNGQ5ZC1hODc4LWExNjVjNTk0MGQwNyIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6InJlZnJlc2gifQ.FHsp7KlVXn1E5tTUiKZzmQ4of39gi57AakeQeqI0oAa8hzjFMVb0RGj-mxWTvHVen4GpgsUW_epqqaxK16viCA
+                  refresh_token_expires_at: '2021-04-22T12:15:05Z'
+                  token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDk0Mjk1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6IjllNjIyOTA2LTc1ZTctNDBiNi1iOTAwLTc1NGIxZjNlZDMyZiIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6ImFjY2VzcyJ9.1JGK9PyHkTtoP_iMu-8TzXH_fhmnsDtZZOAJLDzLW6DDtAb80wZ93l1VH5yNx5tFqwIFG0t48dRiBKWlW-nzDA
+                  token_expires_at: '2021-04-22T12:24:55Z'
+                properties:
+                  refresh_token:
+                    example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
+                    type: string
+                  refresh_token_expires_at:
+                    description: ISO 8601 timestamp when the refresh token expires.
+                    example: '2021-03-26T17:51:59Z'
+                    format: date-time
+                    type: string
+                  token:
+                    example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
+                    type: string
+                  token_expires_at:
+                    description: ISO 8601 timestamp when the token expires.
+                    example: '2021-03-26T17:51:59Z'
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+      description: Create room client token response.
+    CreateRoomCompositionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RoomComposition'
+            type: object
+      description: Create room composition response.
+    CreateRoomResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Room'
+            type: object
+      description: Create room response.
+    CreateSimCardDataUsageNotificationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SimCardDataUsageNotification'
+            type: object
+      description: Successful Response
+    CreateSimCardGroupResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardGroup'
+            type: object
+      description: Successful Response
+    CreateSimCardOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardOrder'
+            type: object
+      description: Successful Response
+    CreateTeXMLSecretResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CreateTeXMLSecretResult'
+            title: Create TeXML Secret request
+            type: object
+      description: Successful response upon creating a TeXML secret.
+    CreateTrafficPolicyProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/TrafficPolicyProfile'
+            type: object
+      description: Successful Response
+    CreateWdrReportResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WdrReport'
+            type: object
+      description: Successful response
+    CreateWirelessBlocklistResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                created_at: '2018-02-02T22:25:27.521Z'
+                id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
+                name: North American Wireless Blocklist
+                record_type: wireless_blocklist
+                type: country
+                updated_at: '2018-02-02T22:25:27.521Z'
+                values:
+                - CA
+                - MX
+                - US
+            properties:
+              data:
+                $ref: '#/components/schemas/WirelessBlocklist'
+            type: object
+      description: Successful Response
+    CredentialConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CredentialConnection'
+            title: Credential Connection Response
+            type: object
+      description: Successful response with details about a credential connection.
+    CredentialsResponseBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CredentialsResponse'
+      description: A response containing a credentials resource.
+    CsvDownloadResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CsvDownload'
+                type: array
+            title: CSV Download Response
+            type: object
+      description: Successful response with details about a CSV download.
+    DefaultGatewayResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/DefaultGateway'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    DeletePhoneNumberResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PhoneNumberDeletedDetailed'
+            title: Phone Number Response
+            type: object
+      description: Successful response with details about a phone number.
+    DeletePrivateWirelessGatewayResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PrivateWirelessGateway'
+            type: object
+      description: Successful Response
+    DeleteSimCardDataUsageNotificationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SimCardDataUsageNotification'
+            type: object
+      description: Successful Response
+    DeleteSimCardGroupResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardGroup'
+            type: object
+      description: Successful Response
+    DeleteSimCardResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCard'
+            type: object
+      description: Successful response
+    DeleteTrafficPolicyProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                properties:
+                  id:
+                    description: Identifies the resource.
+                    example: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
+                    format: uuid
+                    type: string
+                type: object
+            type: object
+      description: Successful Response
+    DeleteWdrReportResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WdrReport'
+            type: object
+      description: Successful response
+    DeleteWirelessBlocklistResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WirelessBlocklist'
+            type: object
+      description: Successful Response
+    DialParticipantResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NewParticipantResource'
+      description: New participant resource.
+    DialogflowConnectionResponseBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DialogflowConnectionResponse'
+      description: Return details of the Dialogflow connection associated with the
+        given CallControl connection.
+    DocReqsListRequirementTypesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DocReqsRequirementTypeList'
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    DocReqsRequirementResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DocReqsRequirement'
+            type: object
+      description: Successful response
+    DocReqsRequirementTypeResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DocReqsRequirementType'
+            type: object
+      description: Successful response
+    DocServiceDocumentResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DocServiceDocument'
+            type: object
+      description: Successful response
+    DownloadDocServiceDocumentResponse:
+      content:
+        '*':
+          schema:
+            format: binary
+            type: string
+      description: Successful response
+    DownloadLOATemplate:
+      content:
+        application/pdf:
+          schema:
+            example: '%PDF-1.4...'
+            format: binary
+            type: string
+      description: Successful response
+    DynamicEmergencyAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DynamicEmergencyAddress'
+            type: object
+      description: Dynamic Emergency Address Response
+    DynamicEmergencyEndpointResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DynamicEmergencyEndpoint'
+            type: object
+      description: Dynamic Emergency Endpoint Response
+    ExternalConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ExternalConnection'
+            title: External Connection Response
+            type: object
+      description: Successful response
+    FaxApplicationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/FaxApplication'
+            title: Fax Application Response
+            type: object
+      description: Successful response
     Forbidden:
       content:
         application/json:
@@ -3681,12 +4639,695 @@ components:
           schema:
             $ref: '#/components/schemas/call-recordings_Errors'
       description: Forbidden. The request is understood but has been refused.
+    FqdnConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/FqdnConnection'
+            title: FQDN Connection Response
+            type: object
+      description: Successful response with details about an FQDN connection.
+    FqdnResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Fqdn'
+            title: FQDN Response
+            type: object
+      description: Successful response with details about an FQDN connection.
     GenericErrorResponse:
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/billing_Errors'
       description: Unexpected error
+    GetAllAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Address'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    GetAllCivicAddressesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CivicAddress'
+                type: array
+            title: Get All Civic Addresses Response
+            type: object
+      description: Successful response
+    GetAllExternalConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ExternalConnection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
+            title: Get All External Connections Response
+            type: object
+      description: Successful response
+    GetAllFaxApplicationsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/FaxApplication'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: Get All Fax Applications Response
+            type: object
+      description: Successful response
+    GetAllPrivateWirelessGatewaysResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PrivateWirelessGateway'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetAllSimCardGroupsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SearchedSIMCardGroup'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetAllSimCardOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SIMCardOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetAllTelephonyCredentialResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/TelephonyCredential'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: Get All Telephony Credential Response
+            type: object
+      description: Successful response with multiple credentials
+    GetAllTexmlApplicationsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/TexmlApplication'
+                type: array
+              meta:
+                $ref: '#/components/schemas/call-scripting_PaginationMeta'
+            title: Get All Texml Applications Response
+            type: object
+      description: Successful response
+    GetAllUserAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/UserAddress'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    GetAllWirelessBlocklistsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WirelessBlocklist'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetCallResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CallResource'
+      description: Call resource.
+    GetCallsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CallResourceIndex'
+      description: Multiple call resources.
+    GetCivicAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CivicAddress'
+            title: Get Civic Address Response
+            type: object
+      description: Successful response
+    GetConferenceRecordingsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConferenceRecordingResourceIndex'
+      description: Multiple conference recording resources.
+    GetConferenceResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConferenceResource'
+      description: Conference resource.
+    GetConferencesResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ConferenceResourceIndex'
+      description: Multiple conference resources.
+    GetExternalConnectionPhoneNumberResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ExternalConnectionPhoneNumber'
+            title: Get External Connection Phone Number Response
+            type: object
+      description: Successful response
+    GetFaxResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Fax'
+            title: Get Fax Response
+            type: object
+      description: Get fax response
+    GetGcbChannelZonesRequestResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GcbChannelZone'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: A list of channel zones
+    GetGcbNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  properties:
+                    number_of_channels:
+                      example: 7
+                      type: integer
+                    numbers:
+                      items:
+                        properties:
+                          country:
+                            example: FR
+                            type: string
+                          number:
+                            example: '+15554441234'
+                            type: string
+                        type: object
+                      type: array
+                    zone_id:
+                      example: 1653e6a1-4bfd-4857-97c6-6a51e1c34477
+                      type: string
+                    zone_name:
+                      example: Euro channel zone
+                      type: string
+                  type: object
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: A list of numbers using GCB, grouped by channel zone
+    GetLogMessageResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              log_messages:
+                items:
+                  $ref: '#/components/schemas/LogMessage'
+                maxItems: 1
+                minItems: 1
+                type: array
+            title: Get Log Message Response
+            type: object
+      description: Successful response
+    GetParticipantResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ParticipantResource'
+      description: Participant resource.
+    GetParticipantsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ParticipantResourceIndex'
+      description: Multiple participant resources.
+    GetPrivateWirelessGatewayResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PrivateWirelessGateway'
+            type: object
+      description: Successful Response
+    GetQueueResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QueueResource'
+      description: Queue resource.
+    GetQueuesResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QueueResourceIndex'
+      description: Multiple queue resources.
+    GetReleaseResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Release'
+            title: Get Release Response
+            type: object
+      description: Successful response
+    GetRoomCompositionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RoomComposition'
+            type: object
+      description: Get room composition response.
+    GetRoomParticipantResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RoomParticipant'
+            type: object
+      description: Get room participant response.
+    GetRoomRecordingResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RoomRecording'
+            type: object
+      description: Get room recording response.
+    GetRoomResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Room'
+            type: object
+      description: Get room response.
+    GetRoomSessionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RoomSession'
+            type: object
+      description: Get room session response.
+    GetSimCardDataUsageNotificationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SimCardDataUsageNotification'
+            type: object
+      description: Successful Response
+    GetSimCardGroupResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardGroup'
+            type: object
+      description: Successful Response
+    GetSimCardOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardOrder'
+            type: object
+      description: Successful Response
+    GetSimCardResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCard'
+            type: object
+      description: Successful response
+    GetTrafficPolicyProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/TrafficPolicyProfile'
+            type: object
+      description: Successful Response
+    GetTrafficPolicyProfileServicesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WirelessPcrfService'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetTrafficPolicyProfilesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/TrafficPolicyProfile'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    GetUploadResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Upload'
+            title: Get Upload Response
+            type: object
+      description: Successful response
+    GetUploadsStatusResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                properties:
+                  pending_numbers_count:
+                    description: The count of phone numbers that are pending assignment
+                      to the external connection.
+                    type: integer
+                  pending_orders_count:
+                    description: The count of number uploads that have not yet been
+                      uploaded to Microsoft.
+                    type: integer
+                type: object
+            title: Get Uploads Status Response
+            type: object
+      description: Successful response
+    GetWdrReportResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WdrReport'
+            type: object
+      description: Successful response
+    GetWdrReportsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WdrReport'
+                type: array
+            type: object
+      description: Successful response
+    GetWirelessBlocklistResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WirelessBlocklist'
+            type: object
+      description: Successful Response
+    GlobalIpAllowedPortListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIPAllowedPort'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpAssignmentListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpAssignment'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    GlobalIpAssignmentResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/GlobalIpAssignment'
+            type: object
+      description: Successful response
+    GlobalIpAssignmentUsageResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpAssignmentUsageMetric'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpHealthCheckListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIPHealthCheck'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    GlobalIpHealthCheckResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/GlobalIPHealthCheck'
+            type: object
+      description: Successful response
+    GlobalIpHealthCheckTypesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpHealthCheckType'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpHealthResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpAssignmentHealthMetric'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpLatencyResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpLatencyMetric'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIP'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    GlobalIpProtocolListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIPProtocol'
+                type: array
+            type: object
+      description: Successful response
+    GlobalIpResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/GlobalIP'
+            type: object
+      description: Successful response
+    GlobalIpUsageResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/GlobalIpUsageMetric'
+                type: array
+            type: object
+      description: Successful response
+    InexplicitNumberOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/InexplicitNumberOrderResponse'
+            title: Inexplicit Number Order Response
+            type: object
+      description: Successful response with details about an inexplicit number order.
+    InexplicitNumberOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/InexplicitNumberOrderResponse'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Inexplicit Number Orders Response
+            type: object
+      description: Successful response with a list of inexplicit number orders.
+    InitiateAICallResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InitiateAICallResult'
+      description: Successful response upon initiating an AI call.
+    InitiateCallResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InitiateCallResult'
+      description: Successful response upon initiating a TeXML call.
     InternalServerErrorResponse:
       content:
         application/json:
@@ -3699,6 +5340,1375 @@ components:
             $ref: '#/components/schemas/call-control_Errors'
       description: Internal server error. An unexpected error occurred on the server.
         This is typically returned for unhandled exceptions or system failures.
+    InventoryCoverageResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/InventoryCoverage'
+                type: array
+              meta:
+                $ref: '#/components/schemas/InventoryCoverageMetadata'
+            type: object
+      description: Successful response with a list of inventory coverage levels
+    InvoiceDetailResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/InvoiceDetail'
+            type: object
+      description: Get invoice details
+    IpConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/IpConnection'
+            title: Ip Connection Response
+            type: object
+      description: Successful response with details about an IP connection.
+    IpResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Ip'
+            title: Ip Response
+            type: object
+      description: Successful response with details about an IP.
+    ListAdvancedOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/AdvancedOrder'
+                type: array
+            type: object
+      description: An array of Advanced Order Responses
+    ListAllowedFocWindows:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrdersAllowedFocWindow'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListAlphanumericSenderIdsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/AlphanumericSenderId'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            type: object
+      description: Successful response with a list of alphanumeric sender IDs.
+    ListAvailablePhoneNumbersBlockResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/AvailablePhoneNumberBlock'
+                type: array
+              meta:
+                $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
+            title: List Available Phone Numbers Blocks Response
+            type: object
+      description: Successful response with a list of available phone numbers blocks.
+    ListAvailablePhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/AvailablePhoneNumber'
+                type: array
+              meta:
+                $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
+              metadata:
+                $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
+            title: List Available Phone Numbers Response
+            type: object
+      description: Successful response with a list of available phone numbers.
+    ListCallControlApplicationsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CallControlApplication'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Call Control Applications Response
+            type: object
+      description: Successful response with a list of call control applications.
+    ListCallEventsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CallEvent'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Call Events Response
+            type: object
+      description: Successful response with a list of call events.
+    ListConferencesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Conference'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Conferences Response
+            type: object
+      description: Successful response with a list of conferences.
+    ListConnectionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Connection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List Connections Response
+            type: object
+      description: Successful response with a list of connections.
+    ListCredentialConnectionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CredentialConnection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List Credential Connections Response
+            type: object
+      description: Successful response with a list of credential connections.
+    ListCsvDownloadsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CsvDownload'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List CSV Downloads Response
+            type: object
+      description: Successful response with a list of CSV downloads.
+    ListCustomerServiceRecordPhoneNumberCoverage:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CustomerServiceRecordPhoneNumberCoverage'
+                type: array
+            type: object
+      description: Successful Response
+    ListCustomerServiceRecords:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/CustomerServiceRecord'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    ListDocServiceDocumentLinksResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/DocServiceDocumentLink'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListDocServiceDocumentsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/DocServiceDocument'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListDraftPortingOrdersWithoutPagination:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+              - activation_settings:
+                  activation_status: null
+                  fast_port_eligible: true
+                  foc_datetime_actual: null
+                  foc_datetime_requested: null
+                created_at: '2022-03-17T18:01:01Z'
+                customer_group_reference: null
+                customer_reference: null
+                description: FP Telnyx
+                documents:
+                  invoice: null
+                  loa: null
+                end_user:
+                  admin:
+                    account_number: null
+                    auth_person_name: null
+                    billing_phone_number: null
+                    business_identifier: null
+                    entity_name: null
+                    pin_passcode: null
+                    tax_identifier: null
+                  location:
+                    administrative_area: null
+                    country_code: null
+                    extended_address: null
+                    locality: null
+                    postal_code: null
+                    street_address: null
+                id: b0ea6d6f-de31-4079-a536-992e0c98b037
+                messaging:
+                  enable_messaging: false
+                  messaging_capable: true
+                  messaging_port_completed: false
+                  messaging_port_status: not_applicable
+                misc: null
+                old_service_provider_ocn: Unreal Communications
+                parent_support_key: null
+                phone_number_configuration:
+                  billing_group_id: null
+                  connection_id: null
+                  emergency_address_id: null
+                  messaging_profile_id: null
+                  tags: []
+                phone_number_type: local
+                phone_numbers:
+                - activation_status: Activate RDY
+                  phone_number: '{e.164 TN}'
+                  phone_number_type: local
+                  portability_status: confirmed
+                  porting_order_id: b0ea6d6f-de31-4079-a536-992e0c98b037
+                  porting_order_status: draft
+                  record_type: porting_phone_number
+                  requirements_status: requirement-info-pending
+                  support_key: sr_10b316
+                porting_phone_numbers_count: 1
+                record_type: porting_order
+                requirements: []
+                requirements_met: false
+                status:
+                  details: []
+                  value: draft
+                support_key: null
+                updated_at: '2022-03-17T18:01:01Z'
+                user_feedback:
+                  user_comment: null
+                  user_rating: null
+                user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
+                webhook_url: null
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrder'
+                type: array
+            type: object
+      description: Successful response
+    ListExternalConnectionPhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ExternalConnectionPhoneNumber'
+                type: array
+              meta:
+                $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
+            title: List External Connection Phone Numbers Response
+            type: object
+      description: Successful response
+    ListFaxesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Fax'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Faxes Response
+            type: object
+      description: List faxes response
+    ListFqdnConnectionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/FqdnConnection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List FQDN Connections Response
+            type: object
+      description: Successful response with a list of FQDN connections.
+    ListFqdnsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Fqdn'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List FQDNs Response
+            type: object
+      description: Successful response with a list of FQDN connections.
+    ListIpConnectionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/IpConnection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List Ip Connections Response
+            type: object
+      description: Successful response with a list of IP connections.
+    ListIpsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Ip'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List Ips Response
+            type: object
+      description: Successful response with a list of IPs.
+    ListLogMessagesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              log_messages:
+                items:
+                  $ref: '#/components/schemas/LogMessage'
+                type: array
+              meta:
+                $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
+            title: List Log Messages Response
+            type: object
+      description: Successful response
+    ListManagedAccountsAllocatableGlobalOutboundChannelsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ManagedAccountsGlobalOutboundChannels'
+            type: object
+      description: Successful response with information about allocatable global outbound
+        channels.
+    ListManagedAccountsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ManagedAccountMultiListing'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response with a list of managed accounts.
+    ListMediaResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MediaResource'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List of media resources response
+            type: object
+      description: A response with a list of media resources
+    ListMessagingHostedNumberOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MessagingHostedNumberOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Hosted Number Order Response
+            type: object
+      description: Successful response with a list of messaging hosted number orders.
+    ListMessagingProfilePhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Profile Phone Numbers Response
+            type: object
+      description: Successful response with a list of messaging profile phone numbers.
+    ListMessagingProfileShortCodesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ShortCode'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Profile Short Codes Response
+            type: object
+      description: Successful response with a list of messaging profile short codes.
+    ListMessagingProfilesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MessagingProfile'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Profiles Response
+            type: object
+      description: Successful response with a list of messaging profiles.
+    ListMessagingUrlDomains:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MessagingUrlDomain'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Profile Url Domains Response
+            type: object
+      description: Successful response with details about a messaging URL domain.
+    ListNumberBlockOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NumberBlockOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Number Block Orders Response
+            type: object
+      description: Successful response with a list of number block orders.
+    ListNumberOrderPhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NumberOrderPhoneNumber'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Number Order Phone Numbers Response
+            type: object
+      description: Successful response with a list of number order phone numbers.
+    ListNumberOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NumberOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Number Orders Response
+            type: object
+      description: Successful response with a list of number orders.
+    ListNumberReservationsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NumberReservation'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Number Reservations Response
+            type: object
+      description: Successful response with a list of number reservations.
+    ListOrganizationUsersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/OrganizationUser'
+                type: array
+              meta:
+                $ref: '#/components/schemas/users_PaginationMeta'
+            title: List Organization Users Response
+            type: object
+      description: Successful response with a list of organization users.
+    ListOutboundVoiceProfilesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/OutboundVoiceProfile'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Outbound Voice Profiles Response
+            type: object
+      description: Successful response
+    ListParticipantsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Participant'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Participants Response
+            type: object
+      description: Successful response with a list of conference participants.
+    ListPhoneNumberBlocksJobsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumberBlocksJob'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Phone Number Blocks Background Jobs Response
+            type: object
+      description: Successful response with a list of phone number blocks background
+        jobs.
+    ListPhoneNumbersJobsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumbersJob'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Phone Numbers Background Jobs Response
+            type: object
+      description: Successful response with a list of phone numbers background jobs.
+    ListPhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumberDetailed'
+                type: array
+              errors:
+                items:
+                  $ref: '#/components/schemas/numbers_Error'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            required:
+            - data
+            - meta
+            title: List Phone Numbers Response
+            type: object
+      description: Successful response with a list of phone numbers.
+    ListPhoneNumbersWithMessagingSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Settings Response
+            type: object
+      description: Successful response with a list of phone numbers with messaging
+        settings.
+    ListPhoneNumbersWithVoiceSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PhoneNumberWithVoiceSettings'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Phone Numbers With Voice Settings Response
+            type: object
+      description: Successful response with a list of phone numbers with voice settings.
+    ListPortingActionRequirements:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingActionRequirement'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingAdditionalDocuments:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+              - created_at: '2023-06-01T10:00:00.00000Z'
+                document_id: 40bc547a-7f96-4cd5-926a-da4842671e88
+                document_type: loa
+                id: 2acd1061-33cb-49b8-8014-beb6dc3fedbf
+                porting_order_id: 9d7b3b8e-4e67-4837-9c44-d110cd2c82a1
+                record_type: porting_additional_document
+                updated_at: '2023-06-01T10:00:00.00000Z'
+              meta:
+                page_number: 1
+                page_size: 25
+                total_pages: 1
+                total_results: 1
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingAdditionalDocument'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingAssociatedPhoneNumbers:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingAssociatedPhoneNumber'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingEventsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingEvent'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingLOAConfigurations:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingLOAConfiguration'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingOrder:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingOrderRequirements:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrderRequirementDetail'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingOrdersActivationJobs:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrdersActivationJob'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingOrdersComments:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrdersComment'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingOrdersExceptionTypes:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingOrdersExceptionType'
+                type: array
+            type: object
+      description: Successful response
+    ListPortingPhoneNumberBlocks:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingPhoneNumberBlock'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingPhoneNumberConfigurations:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingPhoneNumberConfiguration'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingPhoneNumberExtensions:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingPhoneNumberExtension'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingPhoneNumbers:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingPhoneNumber'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+        text/csv:
+          schema:
+            example: "phone_number,phone_number_type,porting_order_id,support_key,porting_order_status\r\
+              \n+12003155566,local,5f940c35-ef28-4408-bb95-af73b047d589,sr_a12345,draft\r\
+              \n"
+            type: string
+      description: Successful response
+    ListPortingReports:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingReport'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortingUKCarriersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingUKCarrier'
+                type: array
+            type: object
+      description: Successful response
+    ListPortingVerificationCodes:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+              - created_at: '2020-10-22T15:00:00.000Z'
+                id: 52090326-6533-4421-bcf4-bd0117cf3954
+                phone_number: '+61424000001'
+                porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
+                updated_at: '2020-10-22T15:00:00.000Z'
+                verified: true
+              - created_at: '2020-10-22T15:00:00.000Z'
+                id: cf076b8e-645b-4040-8209-543c5909775f
+                phone_number: '+61424000002'
+                porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
+                updated_at: '2020-10-22T15:00:00.000Z'
+                verified: false
+              meta:
+                page_number: 1
+                page_size: 2
+                total_pages: 1
+                total_results: 2
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingVerificationCode'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortoutComments:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortoutComment'
+                type: array
+              meta:
+                $ref: '#/components/schemas/Metadata'
+            type: object
+      description: Portout Comments
+    ListPortoutEventsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortoutEvent'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortoutRejections:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortoutRejection'
+                type: array
+            type: object
+      description: Successful response
+    ListPortoutReports:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortoutReport'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListPortoutResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortoutDetails'
+                type: array
+              meta:
+                $ref: '#/components/schemas/Metadata'
+            type: object
+      description: Portout Response
+    ListQueueCallsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/QueueCall'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Queue Calls Response
+            type: object
+      description: Successful response with a list of calls in a queue.
+    ListQueuesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Queue'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Queues Response
+            type: object
+      description: Successful response with a list of queues.
+    ListRecordingTranscriptionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RecordingTranscription'
+                type: array
+              meta:
+                $ref: '#/components/schemas/call-recordings_CursorPaginationMeta'
+            type: object
+      description: A response listing multiple recording transcriptions.
+    ListReleasesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Release'
+                type: array
+              meta:
+                $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
+            title: List Releases Response
+            type: object
+      description: Successful response
+    ListRequirementsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/DocReqsRequirementList'
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    ListRoomCompositionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RoomComposition'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: List room compositions response.
+    ListRoomParticipantsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RoomParticipant'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: List room participants response.
+    ListRoomRecordingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RoomRecording'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: List room recordings response.
+    ListRoomSessionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RoomSession'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: List room sessions response.
+    ListRoomsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Room'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: List rooms response.
+    ListShortCodesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/ShortCode'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Short Codes Response
+            type: object
+      description: Successful response with a list of short codes.
+    ListSubNumberOrdersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SubNumberOrder'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Sub Number Orders Response
+            type: object
+      description: Successful response with a list of sub number orders.
+    ListUacConnectionsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/UacConnection'
+                type: array
+              meta:
+                $ref: '#/components/schemas/connections_PaginationMeta'
+            title: List UAC Connections Response
+            type: object
+      description: Successful response with a list of UAC connections.
+    ListUploadsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Upload'
+                type: array
+              meta:
+                $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
+            title: List Uploads Response
+            type: object
+      description: Successful response
+    ListUserTagsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                properties:
+                  number_tags:
+                    $ref: '#/components/schemas/UserTagList'
+                  outbound_profile_tags:
+                    $ref: '#/components/schemas/UserTagList'
+                type: object
+            type: object
+      description: A list of your tags
+    ListWebhookDeliveriesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/webhook_delivery'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMetaSimple'
+            type: object
+      description: A paginated array of webhook_delivery attempts
+    ManagedAccountResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ManagedAccount'
+            type: object
+      description: Successful response with information about a single managed account.
+    MediaDownloadResponse:
+      content:
+        application/octet-stream:
+          schema:
+            format: binary
+            type: string
+      description: A response describing a media resource
+    MediaResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/MediaResource'
+            title: Media resource response
+            type: object
+      description: A response describing a media resource
+    MessageResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/OutboundMessagePayload'
+            title: Message Response
+            type: object
+      description: Successful response with details about a message.
+    MessagingHostedNumberOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/MessagingHostedNumberOrder'
+            title: Retrieve Messaging Hosted Number Order Response
+            type: object
+      description: Successful response with details about a messaging hosted number
+        order.
+    MessagingProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/MessagingProfile'
+            title: Messaging Profile Response
+            type: object
+      description: Successful response with details about a messaging profile.
+    MobileListPhoneNumbersWithMessagingSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MobilePhoneNumberWithMessagingSettings'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            title: List Messaging Settings Response
+            type: object
+      description: Successful response with a list of mobile phone numbers with messaging
+        settings.
+    MobilePhoneNumberWithMessagingSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/MobilePhoneNumberWithMessagingSettings'
+            title: Retrieve Mobile Messaging Settings Response
+            type: object
+      description: Successful response with details about a mobile phone number.
+    NetworkCoverageListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NetworkCoverage'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    NetworkInterfaceListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/NetworkInterface'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    NetworkListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Network'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    NetworkResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Network'
+            type: object
+      description: Successful response
     NotFoundErrorResponse:
       content:
         application/json:
@@ -3762,6 +6772,379 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
       description: The requested resource doesn't exist.
+    NumberBlockOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/NumberBlockOrder'
+            title: Number Block Order Response
+            type: object
+      description: Successful response with details about a number block order.
+    NumberLookupResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/NumberLookupRecord'
+            title: Number Lookup Response
+            type: object
+      description: Successful response
+    NumberOrderPhoneNumberResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/NumberOrderPhoneNumber'
+            title: Number Order Phone Number Response
+            type: object
+      description: Successful response with details about a number order phone number.
+    NumberOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/NumberOrderWithPhoneNumbers'
+            title: Number Order Response
+            type: object
+      description: Successful response with details about a number order.
+    NumberReservationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/NumberReservation'
+            title: Number Reservation Response
+            type: object
+      description: Successful response with details about a number reservation.
+    OTAUpdateResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CompleteOTAUpdate'
+            type: object
+      description: Successful response
+    OrganizationUserResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/OrganizationUser'
+            title: Organization User Response
+            type: object
+      description: Successful response with details about an Organization User.
+    OutboundVoiceProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/OutboundVoiceProfile'
+            title: Outbound Voice Profile Response
+            type: object
+      description: Successful response
+    PatchGcbChannelZoneRequestResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GcbChannelZone'
+      description: Successfuly patched channel zone
+    PatchRoomResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Room'
+            type: object
+      description: Update room response.
+    PhoneNumberResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PhoneNumberDetailed'
+            title: Phone Number Response
+            type: object
+      description: Successful response with details about a phone number.
+    PhoneNumberWithMessagingSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
+            title: Retrieve Messaging Settings Response
+            type: object
+      description: Successful response with details about a phone number including
+        messaging settings.
+    PhoneNumberWithVoiceSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PhoneNumberWithVoiceSettings'
+            title: Retrieve Phone Number Voice Response
+            type: object
+      description: Successful response with details about a phone number including
+        voice settings.
+    PortOutListSupportingDocumentsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortOutSupportingDocument'
+                type: array
+            type: object
+      description: Portout Supporting Documents
+    PortabilityCheckResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortabilityCheckDetails'
+                type: array
+            type: object
+      description: PortabilityCheck Response
+    PortoutCommentResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortoutComment'
+            type: object
+      description: Portout Comment Response
+    PortoutResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortoutDetails'
+            type: object
+      description: Portout Response
+    PublicInternetGatewayListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PublicInternetGatewayRead'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    PublicInternetGatewayResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PublicInternetGatewayRead'
+            type: object
+      description: Successful response
+    QueueCallResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/QueueCall'
+            title: Queue Call Response
+            type: object
+      description: Successful response with details about a call in a queue.
+    QueueResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Queue'
+            title: Queue Response
+            type: object
+      description: Successful response with details about a queue.
+    ReadCommentResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                allOf:
+                - $ref: '#/components/schemas/ReadComment'
+                - type: object
+            type: object
+      description: A Comment Response
+    RecordingResponseBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RecordingResponse'
+      description: A response with a single recording resource.
+    RecordingTranscriptionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/RecordingTranscription'
+            type: object
+      description: A response with a single recording transcription resource.
+    RecordingsResponseBody:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RecordingResponseData'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: A response containing multiple recordings.
+    RefreshFaxResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                result: ok
+            properties:
+              data:
+                properties:
+                  result:
+                    example: ok
+                    type: string
+                type: object
+            title: Refresh Fax Response
+            type: object
+      description: Refresh fax response
+    RefreshRoomClientTokenResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                example:
+                  token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDk0Mjk1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6IjllNjIyOTA2LTc1ZTctNDBiNi1iOTAwLTc1NGIxZjNlZDMyZiIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6ImFjY2VzcyJ9.1JGK9PyHkTtoP_iMu-8TzXH_fhmnsDtZZOAJLDzLW6DDtAb80wZ93l1VH5yNx5tFqwIFG0t48dRiBKWlW-nzDA
+                  token_expires_at: '2021-04-22T12:24:55Z'
+                properties:
+                  token:
+                    example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
+                    type: string
+                  token_expires_at:
+                    description: ISO 8601 timestamp when the token expires.
+                    example: '2021-03-26T17:51:59Z'
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+      description: Refresh room client token response.
+    RegionListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/netapps_Region'
+                type: array
+            type: object
+      description: Successful response
+    RegisterSimCardsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                description: Successfully registered SIM cards.
+                items:
+                  $ref: '#/components/schemas/SimpleSIMCard'
+                type: array
+              errors:
+                items:
+                  $ref: '#/components/schemas/wireless_Error'
+                type: array
+            type: object
+      description: Successful response
+    RegistrationStatusResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                example:
+                  ip_address: 190.106.106.121
+                  last_registration: '2021-09-28T15:11:02'
+                  port: 37223
+                  record_type: registration_status
+                  sip_username: rogerp
+                  status: Expired
+                  transport: UDP
+                  user_agent: Z 5.4.12 v2.10.13.2-mod
+                properties:
+                  ip_address:
+                    description: The ip used during the SIP connection
+                    example: 190.106.106.121
+                    type: string
+                  last_registration:
+                    description: ISO 8601 formatted date indicating when the resource
+                      was last updated.
+                    example: '2018-02-02T22:25:27.521Z'
+                    type: string
+                  port:
+                    description: The port of the SIP connection
+                    example: 37223
+                    type: integer
+                  record_type:
+                    description: Identifies the type of the resource.
+                    example: registration_status
+                    type: string
+                  sip_username:
+                    description: The user name of the SIP connection
+                    example: sip_username
+                    type: string
+                  status:
+                    description: The current registration status of your SIP connection
+                    enum:
+                    - Not Applicable
+                    - Not Registered
+                    - Failed
+                    - Expired
+                    - Registered
+                    - Unregistered
+                    type: string
+                  transport:
+                    description: The protocol of the SIP connection
+                    example: TCP
+                    type: string
+                  user_agent:
+                    description: The user agent of the SIP connection
+                    example: Z 5.4.12 v2.10.13.2-mod
+                    type: string
+                title: Registration Status
+                type: object
+            title: Registration Status Response
+            type: object
+      description: Successful response with details about a credential connection
+        registration status.
     ResourceNotFound:
       content:
         application/json:
@@ -3778,6 +7161,130 @@ components:
                   $ref: '#/components/schemas/customer_service_record_ResourceNotFoundError'
                 type: array
       description: Resource not found
+    RetrieveCallStatusResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Call'
+            title: Retrieve Call Status Response
+            type: object
+      description: Successful response with details about a call status.
+    RetrieveCallStatusResponseWithRecordingId:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CallWithRecordingId'
+            title: Retrieve Call Status Response With Recording ID
+            type: object
+      description: Successful response with details about a call status that includes
+        recording_id.
+    SIMCardActionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardAction'
+            type: object
+      description: Successful Response
+    SIMCardActivationCodeResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardActivationCode'
+            type: object
+      description: Successful response
+    SIMCardDeviceDetailsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardDeviceDetails'
+            type: object
+      description: Successful response
+    SIMCardGroupActionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardGroupAction'
+            type: object
+      description: Successful Response
+    SIMCardOrdersPreviewResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardOrderPreview'
+            type: object
+      description: Successful Response
+    SIMCardPublicIPResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardPublicIP'
+            type: object
+      description: Successful response
+    SearchMobileNetworkOperatorsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/MobileNetworkOperator'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    SearchOTAUpdateResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SimplifiedOTAUpdate'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    SearchSimCardsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SimpleSIMCard'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    SendFaxResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/Fax'
+            title: Send Fax Response
+            type: object
+      description: Send fax response
     ServiceUnavailableErrorResponse:
       content:
         application/json:
@@ -3796,6 +7303,387 @@ components:
             $ref: '#/components/schemas/call-control_Errors'
       description: Service unavailable. The service is temporarily unavailable. This
         may occur during maintenance or when the service is overloaded.
+    SharePortingOrder:
+      content:
+        application/json:
+          example:
+            data:
+              created_at: '2023-07-20T22:11:17.292573Z'
+              expires_at: '2023-07-20T23:11:17Z'
+              expires_in_seconds: 3600
+              id: 03a35311-ad92-46b3-95d7-8ad6dccf2d7c
+              permissions:
+              - porting_order.document.read
+              - porting_order.document.update
+              porting_order_id: fd4b86c8-497d-4c6d-9609-a789e4e14cfe
+              record_type: porting_order_sharing_token
+              token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODk4OTQ2NzcsImlzdCI6MTY4OTg5MTA3NywicGVybWlzc2lvbnMiOlsicG9ydGluZ19vcmRlci5kb2N1bWVudC5yZWFkIl0sInBvcnRpbmdfb3JkZXJfaWQiOiJmZDRiODZjOC00OTdkLTRjNmQtOTYwOS1hNzg5ZTRlMTRjZmUifQ.CT0HRF6OLj7VPZ8p5Y_0S8rOL8SEUznwJJkR-YReKwc
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrderSharingToken'
+            type: object
+      description: Successful response
+    ShortCodeResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ShortCode'
+            title: Short Code Response
+            type: object
+      description: Successful response with details about a short code.
+    ShowCustomerServiceRecord:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CustomerServiceRecord'
+            type: object
+      description: Successful Response
+    ShowPortingActionRequirement:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingActionRequirement'
+            type: object
+      description: Successful response
+    ShowPortingAssociatedPhoneNumber:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingAssociatedPhoneNumber'
+            type: object
+      description: Successful response
+    ShowPortingEventResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingEvent'
+            type: object
+      description: Successful response
+    ShowPortingLOAConfiguration:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingLOAConfiguration'
+            type: object
+      description: Successful response
+    ShowPortingOrder:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrder'
+              meta:
+                properties:
+                  phone_numbers_url:
+                    description: Link to list all phone numbers
+                    example: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
+                    type: string
+                type: object
+            type: object
+      description: Successful response
+    ShowPortingOrdersActivationJob:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrdersActivationJob'
+            type: object
+      description: Successful response
+    ShowPortingOrdersComment:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrdersComment'
+            type: object
+      description: Successful response
+    ShowPortingPhoneNumberBlock:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingPhoneNumberBlock'
+            type: object
+      description: Successful response
+    ShowPortingPhoneNumberExtension:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingPhoneNumberExtension'
+            type: object
+      description: Successful response
+    ShowPortingReport:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingReport'
+            type: object
+      description: Successful response
+    ShowPortoutEventResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortoutEvent'
+            type: object
+      description: Successful response
+    ShowPortoutReport:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortoutReport'
+            type: object
+      description: Successful response
+    SimCardActionCollectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SIMCardAction'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    SimCardDataUsageNotificationCollectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SimCardDataUsageNotification'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    SimCardGroupActionCollectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SIMCardGroupAction'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
+    SinglePhoneNumberCampaign:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PhoneNumberCampaign'
+      description: Successful Response
+    SiprecConnectorResponseBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SiprecConnectorResponse'
+      description: Return details of the SIPREC connector.
+    SlimListPhoneNumbersResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/SlimPhoneNumberDetailed'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            title: List Phone Numbers Response
+            type: object
+      description: Successful response with a list of phone numbers.
+    SpecificCountryResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/CountryCoverage'
+            type: object
+      description: Response for specific country coverage
+    SubNumberOrderResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SubNumberOrder'
+            title: Sub Number Order Response
+            type: object
+      description: Successful response with details about a sub number order.
+    SubNumberOrdersReportResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SubNumberOrdersReport'
+            type: object
+      description: Sub number orders report response
+    SubRequestByPortingOrder:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/GetSubRequestByPortingOrder'
+            type: object
+      description: Successful response
+    TelephonyCredentialResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/TelephonyCredential'
+            title: Telephony Credential Response
+            type: object
+      description: Successful response with details about a credential
+    TexmlApplicationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/TexmlApplication'
+            title: Texml Application Response
+            type: object
+      description: Successful response
+    TexmlCreateCallRecordingResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlCreateCallRecordingResponseBody'
+      description: Successful call recording create response
+    TexmlCreateCallStreamingResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlCreateCallStreamingResponseBody'
+      description: Successful call streaming create response
+    TexmlCreateSiprecSessionResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlCreateSiprecSessionResponseBody'
+      description: Successful SIPREC session create response
+    TexmlGetCallRecordingResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlGetCallRecordingResponseBody'
+      description: Retrieves call recording resource.
+    TexmlGetCallRecordingsResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlGetCallRecordingsResponseBody'
+      description: Successful Get Call Recordings Response
+    TexmlGetRecordingTranscriptionResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlRecordingTranscription'
+            title: Recording Transcription Response
+            type: object
+      description: Successful get Recording Transcription Response
+    TexmlListRecordingTranscriptionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              end:
+                description: The number of the last element on the page, zero-indexed
+                example: 1
+                type: integer
+              first_page_uri:
+                description: Relative uri to the first page of the query results
+                format: uri
+                type: string
+              next_page_uri:
+                description: Relative uri to the next page of the query results
+                example: /v2/texml/Accounts/61bf923e-5e4d-4595-a110-56190ea18a1b/Transcriptions.json?PageToken=KRWXZPO&PageSize=1
+                type: string
+              page:
+                description: Current page number, zero-indexed.
+                example: 0
+                type: integer
+              page_size:
+                description: The number of items on the page
+                example: 20
+                type: integer
+              previous_page_uri:
+                description: Relative uri to the previous page of the query results
+                format: uri
+                type: string
+              start:
+                description: The number of the first element on the page, zero-indexed.
+                example: 0
+                type: integer
+              transcriptions:
+                items:
+                  $ref: '#/components/schemas/TexmlRecordingTranscription'
+                type: array
+              uri:
+                description: The URI of the current page.
+                example: /v2/texml/Accounts/61bf923e-5e4d-4595-a110-56190ea18a1b/Transcriptions.json?PageToken=YTBNAXPI&PageSize=1
+                type: string
+            title: List Recording Transcriptions Response
+            type: object
+      description: Successful list Recording Transcriptions Response
+    TexmlUpdateCallStreamingResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlUpdateCallStreamingResponseBody'
+      description: Successful call streaming update response
+    TexmlUpdateSiprecSessionResponse:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TexmlUpdateSiprecSessionResponseBody'
+      description: Successful SIPREC session update response
+    UacConnectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/UacConnection'
+            title: UAC Connection Response
+            type: object
+      description: Successful response with details about a UAC connection.
     UnauthenticatedResponse:
       content:
         application/json:
@@ -4047,6 +7935,453 @@ components:
             type: object
       description: Unprocessable entity. Check the 'detail' field in response for
         details.
+    UpdateManagedAccountGlobalChannelLimitResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SingleManagedAccountGlobalOutboundChannels'
+            type: object
+      description: Successful response with information about the allocatable global
+        outbound channels for the given account.
+    UpdatePortingLOAConfiguration:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingLOAConfiguration'
+            type: object
+      description: Successful response
+    UpdatePortingOrderResponse:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+                activation_settings:
+                  activation_status: null
+                  fast_port_eligible: true
+                  foc_datetime_actual: null
+                  foc_datetime_requested: '2022-04-08T15:00:00Z'
+                created_at: '2022-03-24T14:22:28Z'
+                customer_group_reference: Group-789
+                customer_reference: Test1234
+                description: FP Telnyx
+                documents:
+                  invoice: null
+                  loa: null
+                end_user:
+                  admin:
+                    account_number: 123abc
+                    auth_person_name: Porter McPortersen II
+                    billing_phone_number: '+13035551234'
+                    business_identifier: abc123
+                    entity_name: Porter McPortersen
+                    pin_passcode: '1234'
+                    tax_identifier: 1234abcd
+                  location:
+                    administrative_area: TX
+                    country_code: US
+                    extended_address: 14th Floor
+                    locality: Austin
+                    postal_code: '78701'
+                    street_address: 600 Congress Avenue
+                id: eef10fb8-f3df-4c67-97c5-e18179723222
+                messaging:
+                  enable_messaging: true
+                  messaging_capable: true
+                  messaging_port_completed: false
+                  messaging_port_status: pending
+                misc:
+                  new_billing_phone_number: null
+                  remaining_numbers_action: null
+                  type: full
+                old_service_provider_ocn: Unreal Communications
+                parent_support_key: null
+                phone_number_configuration:
+                  billing_group_id: null
+                  connection_id: '1752379429071357070'
+                  emergency_address_id: null
+                  messaging_profile_id: null
+                  tags: []
+                phone_number_type: local
+                porting_phone_numbers_count: 1
+                record_type: porting_order
+                requirements: []
+                requirements_met: false
+                status:
+                  details: []
+                  value: draft
+                support_key: null
+                updated_at: '2022-03-24T14:26:53Z'
+                user_feedback:
+                  user_comment: null
+                  user_rating: null
+                user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
+                webhook_url: https://example.com/porting_webhooks
+              meta:
+                phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
+            properties:
+              data:
+                $ref: '#/components/schemas/PortingOrder'
+              meta:
+                properties:
+                  phone_numbers_url:
+                    description: Link to list all phone numbers
+                    type: string
+                type: object
+            type: object
+      description: Successful response
+    UpdateSimCardDataUsageNotificationResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SimCardDataUsageNotification'
+            type: object
+      description: Successful Response
+    UpdateSimCardGroupResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCardGroup'
+            type: object
+      description: Successful Response
+    UpdateSimCardResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/SIMCard'
+            type: object
+      description: Successful response
+    UpdateTrafficPolicyProfileResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/TrafficPolicyProfile'
+            type: object
+      description: Successful Response
+    UpdateWirelessBlocklistResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WirelessBlocklist'
+            type: object
+      description: Successful response
+    UserAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/UserAddress'
+            type: object
+      description: Successful response
+    UserBalanceResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/UserBalance'
+            type: object
+      description: Get user balance details
+    UsersGroupsReportResponse:
+      content:
+        application/json:
+          example:
+            data:
+            - created_at: '2018-02-02T22:25:27.521Z'
+              email: user@example.com
+              groups:
+              - id: 7b09cdc3-8948-47f0-aa62-74ac943d6c59
+                name: Engineering
+              - id: 8c09cdc3-8948-47f0-aa62-74ac943d6c60
+                name: Sales
+              id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
+              last_sign_in_at: '2018-02-02T22:25:27.521Z'
+              organization_user_bypasses_sso: false
+              record_type: organization_sub_user
+              user_status: enabled
+            - created_at: '2018-01-01T00:00:00.000Z'
+              email: owner@example.com
+              groups: []
+              id: 9d09cdc3-8948-47f0-aa62-74ac943d6c61
+              last_sign_in_at: '2018-02-02T22:25:27.521Z'
+              organization_user_bypasses_sso: false
+              record_type: organization_owner
+              user_status: enabled
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/OrganizationUserWithGroups'
+                type: array
+            title: Users Groups Report Response
+            type: object
+        text/csv:
+          example: 'id,email,user_status,created_at,last_sign_in_at,groups
+
+            6a09cdc3-8948-47f0-aa62-74ac943d6c58,user@example.com,enabled,2018-02-02T22:25:27.521Z,2018-02-02T22:25:27.521Z,"Engineering,
+            Sales"'
+          schema:
+            description: 'CSV formatted report of users and their groups. Columns:
+              id, email, user_status, created_at, last_sign_in_at, groups (comma-separated
+              list of group names).'
+            type: string
+      description: Successful response with a list of organization users and their
+        group memberships.
+    ValidateAddressResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ValidateAddressResult'
+            title: Validate address action response
+            type: object
+      description: Action response
+    ValidationCodesResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/ValidationCodes'
+            title: Retrieve Messaging Hosted Number Response
+            type: object
+      description: Successful response with the phone numbers and their respective
+        status of the validation codes.
+    VerifyPortingVerificationCodes:
+      content:
+        application/json:
+          schema:
+            example:
+              data:
+              - created_at: '2020-10-22T15:00:00.000Z'
+                id: 52090326-6533-4421-bcf4-bd0117cf3954
+                phone_number: '+61424000001'
+                porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
+                updated_at: '2020-10-22T15:00:00.000Z'
+                verified: true
+              - created_at: '2020-10-22T15:00:00.000Z'
+                id: cf076b8e-645b-4040-8209-543c5909775f
+                phone_number: '+61424000002'
+                porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
+                updated_at: '2020-10-22T15:00:00.000Z'
+                verified: false
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/PortingVerificationCode'
+                type: array
+            type: object
+      description: Successful response
+    VirtualCrossConnectCoverageListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/VirtualCrossConnectCoverage'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    VirtualCrossConnectListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/VirtualCrossConnectCombined'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    VirtualCrossConnectResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/VirtualCrossConnectCombined'
+            type: object
+      description: Successful response
+    VoicemailResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/VoicemailPrefResponse'
+            type: object
+      description: Successful response
+    WabaSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WabaSettings'
+            type: object
+      description: Successful response with Whatsapp business account settings
+    WabaSingleResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WabaResponse'
+            type: object
+      description: Successful response with Whatsapp business account
+    WabasListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WabaResponse'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            type: object
+      description: Successful response with list of Whatsapp business accounts
+    WhatsappCallingSettingsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WhatsappCallingSettingsData'
+            type: object
+      description: Successful response with Whatsapp calling settings
+    WhatsappPhonesListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WhatsappPhoneResponse'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            type: object
+      description: Successful response with Whatsapp phone numbers
+    WhatsappProfileSingleResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WhatsappProfileData'
+            type: object
+      description: Successful response with Whatsapp profile
+    WhatsappTemplateListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WhatsappTemplateData'
+                type: array
+              meta:
+                $ref: '#/components/schemas/messaging_PaginationMeta'
+            type: object
+      description: Successful response with Whatsapp template
+    WhatsappTemplateSingleResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WhatsappTemplateData'
+            type: object
+      description: Successful response with Whatsapp template
+    WhatsappUserDataResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WhatsappUserData'
+            type: object
+      description: Successful response with Whatsapp user data
+    WireguardInterfaceListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WireguardInterfaceRead'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    WireguardInterfaceResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WireguardInterfaceRead'
+            type: object
+      description: Successful response
+    WireguardPeerListResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WireguardPeer'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful response
+    WireguardPeerResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/WireguardPeer'
+            type: object
+      description: Successful response
+    WirelessConnectivityLogCollectionResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/WirelessConnectivityLog'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: Successful Response
     billing_ForbiddenErrorResponse:
       content:
         application/json:
@@ -4511,6 +8846,69 @@ components:
           schema:
             $ref: '#/components/schemas/invoice_Errors'
       description: Invoice not found
+    listCommentsResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/Comment'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: An array of Comment Responses
+    listDynamicEmergencyAddresses:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/DynamicEmergencyAddress'
+                type: array
+              meta:
+                $ref: '#/components/schemas/Metadata'
+            type: object
+      description: Dynamic Emergency Address Responses
+    listDynamicEmergencyEndpoints:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/DynamicEmergencyEndpoint'
+                type: array
+              meta:
+                $ref: '#/components/schemas/Metadata'
+            type: object
+      description: Dynamic Emergency Endpoints Responses
+    listRegulatoryRequirements:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RegulatoryRequirements'
+                type: array
+            type: object
+      description: An array of Regulatory Requirements Responses
+    listRegulatoryRequirementsPhoneNumbers:
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/components/schemas/RegulatoryRequirementsPhoneNumbers'
+                type: array
+              meta:
+                $ref: '#/components/schemas/PaginationMeta'
+            type: object
+      description: An array of Regulatory Requirements Responses
     managed-accounts_ForbiddenResponse:
       description: Unauthorized response. Happens when the current user is not authorized
         to access the endpoint.
@@ -68599,7 +72997,6 @@ paths:
       x-latency-category: responsive
   /10dlc/brand/{brandId}/2faEmail:
     post:
-      description: Resend brand 2FA email
       operationId: ResendBrand2faEmail
       parameters:
       - description: Unique identifier of the brand.
@@ -69044,7 +73441,6 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/usecase/cost:
     get:
-      description: Get Campaign Cost
       operationId: GetCampaignCost
       parameters:
       - description: Filter results by usecase.
@@ -69316,7 +73712,6 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/{campaignId}/osr/attributes:
     get:
-      description: Get OSR campaign attributes
       operationId: GetCampaignOsrAttributes
       parameters:
       - description: Unique identifier of the campaign.
@@ -69352,7 +73747,6 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/{campaignId}/sharing:
     get:
-      description: Get Sharing Status
       operationId: GetCampaignSharingStatus
       parameters:
       - description: ID of the campaign in question
@@ -69470,7 +73864,6 @@ paths:
       x-latency-category: responsive
   /10dlc/enum/{endpoint}:
     get:
-      description: Get Enum
       operationId: GetEnumEndpoint
       parameters:
       - description: Unique identifier of the endpoint.
@@ -69576,7 +73969,6 @@ paths:
       x-latency-category: responsive
   /10dlc/partnerCampaign/{campaignId}/sharing:
     get:
-      description: Get Sharing Status
       operationId: GetPartnerCampaignSharingStatus
       parameters:
       - description: ID of the campaign in question
@@ -69861,7 +74253,6 @@ paths:
       x-latency-category: responsive
   /10dlc/phone_number_campaigns:
     get:
-      description: List phone number campaigns
       operationId: GetAllPhoneNumberCampaigns
       parameters:
       - description: Number of records to return per page.
@@ -69914,7 +74305,6 @@ paths:
       - Phone Number Campaigns
       x-latency-category: responsive
     post:
-      description: Create New Phone Number Campaign
       operationId: CreatePhoneNumberCampaign
       parameters: []
       requestBody:
@@ -69951,11 +74341,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PhoneNumberCampaign'
-          description: Successful Response
+          $ref: '#/components/responses/SinglePhoneNumberCampaign'
         4XX:
           $ref: '#/components/responses/10dlc_GenericErrorResponse'
       summary: Delete Phone Number Campaign
@@ -69987,7 +74373,6 @@ paths:
       - Phone Number Campaigns
       x-latency-category: responsive
     put:
-      description: Create New Phone Number Campaign
       operationId: PutPhoneNumberCampaign
       parameters:
       - description: Unique identifier of the phone number.
@@ -70018,7 +74403,6 @@ paths:
       x-latency-category: responsive
   /access_ip_address:
     get:
-      description: List all Access IP Addresses
       operationId: ListAccessIpAddresses
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -70148,7 +74532,6 @@ paths:
       - IP Addresses
       x-latency-category: responsive
     post:
-      description: Create new Access IP Address
       operationId: CreateAccessIpAddress
       requestBody:
         content:
@@ -70175,7 +74558,6 @@ paths:
       x-latency-category: responsive
   /access_ip_address/{access_ip_address_id}:
     delete:
-      description: Delete access IP address
       operationId: DeleteAccessIpAddress
       parameters:
       - description: Unique identifier of the access ip address.
@@ -70202,7 +74584,6 @@ paths:
       - IP Addresses
       x-latency-category: responsive
     get:
-      description: Retrieve an access IP address
       operationId: GetAccessIpAddress
       parameters:
       - description: Unique identifier of the access ip address.
@@ -70230,7 +74611,6 @@ paths:
       x-latency-category: responsive
   /access_ip_ranges:
     get:
-      description: List all Access IP Ranges
       operationId: ListAccessIpRanges
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -70386,7 +74766,6 @@ paths:
       - IP Ranges
       x-latency-category: responsive
     post:
-      description: Create new Access IP Range
       operationId: CreateAccessIPRange
       requestBody:
         content:
@@ -70413,7 +74792,6 @@ paths:
       x-latency-category: responsive
   /access_ip_ranges/{access_ip_range_id}:
     delete:
-      description: Delete access IP ranges
       operationId: DeleteAccessIpRange
       parameters:
       - description: Unique identifier of the access ip range.
@@ -70458,21 +74836,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    description: Successfully registered SIM cards.
-                    items:
-                      $ref: '#/components/schemas/SimpleSIMCard'
-                    type: array
-                  errors:
-                    items:
-                      $ref: '#/components/schemas/wireless_Error'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/RegisterSimCardsResponse'
         '401':
           description: Unauthorized
       summary: Purchase eSIMs
@@ -70498,21 +74862,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    description: Successfully registered SIM cards.
-                    items:
-                      $ref: '#/components/schemas/SimpleSIMCard'
-                    type: array
-                  errors:
-                    items:
-                      $ref: '#/components/schemas/wireless_Error'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/RegisterSimCardsResponse'
         '401':
           description: Unauthorized
       summary: Register SIM cards
@@ -70529,18 +74879,7 @@ paths:
       - $ref: '#/components/parameters/SortAddress'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Address'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllAddressResponse'
         '400':
           description: Bad request
         '401':
@@ -70565,14 +74904,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Address'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/AddressResponse'
         '422':
           description: Bad request
       summary: Creates an address
@@ -70594,15 +74926,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ValidateAddressResult'
-                title: Validate address action response
-                type: object
-          description: Action response
+          $ref: '#/components/responses/ValidateAddressResponse'
         '422':
           description: Bad request
       summary: Validate an address
@@ -70622,14 +74946,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Address'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/AddressResponse'
         '401':
           description: Unauthorized
         '404':
@@ -70652,14 +74969,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Address'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/AddressResponse'
         '401':
           description: Unauthorized
         '404':
@@ -70672,9 +74982,6 @@ paths:
       x-latency-category: responsive
   /addresses/{id}/actions/accept_suggestions:
     post:
-      description: Accepts this address suggestion as a new emergency address for
-        Operator Connect and finishes the uploads of the numbers associated with it
-        to Microsoft.
       operationId: acceptAddressSuggestions
       parameters:
       - description: The UUID of the address that should be accepted.
@@ -70717,20 +75024,10 @@ paths:
       x-latency-category: responsive
   /advanced_orders:
     get:
-      description: List Advanced Orders
       operationId: list_advanced_orders_v2
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/AdvancedOrder'
-                    type: array
-                type: object
-          description: An array of Advanced Order Responses
+          $ref: '#/components/responses/ListAdvancedOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -70746,7 +75043,6 @@ paths:
       - Advanced Number Orders
       x-latency-category: responsive
     post:
-      description: Create Advanced Order
       operationId: create_advanced_order_v2
       requestBody:
         content:
@@ -70756,11 +75052,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvancedOrder'
-          description: An Advanced Order Response
+          $ref: '#/components/responses/AdvancedOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -70777,7 +75069,6 @@ paths:
       x-latency-category: responsive
   /advanced_orders/{advanced-order-id}/requirement_group:
     patch:
-      description: Update Advanced Order
       operationId: update_advanced_order_v2
       parameters:
       - description: Unique identifier of the advanced order.
@@ -70796,11 +75087,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvancedOrder'
-          description: An Advanced Order Response
+          $ref: '#/components/responses/AdvancedOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -70817,7 +75104,6 @@ paths:
       x-latency-category: responsive
   /advanced_orders/{order_id}:
     get:
-      description: Get Advanced Order
       operationId: get_advanced_order_v2
       parameters:
       - description: Unique identifier of the order.
@@ -70830,11 +75116,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvancedOrder'
-          description: An Advanced Order Response
+          $ref: '#/components/responses/AdvancedOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -70927,7 +75209,6 @@ paths:
       x-latency-category: responsive
   /ai/assistants/tags:
     get:
-      description: Get All Tags
       operationId: get_all_assistant_tags
       responses:
         '200':
@@ -71943,7 +76224,6 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tags:
     post:
-      description: Add Assistant Tag
       operationId: add_assistant_tag
       parameters:
       - description: Unique identifier of the assistant.
@@ -71978,7 +76258,6 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tags/{tag}:
     delete:
-      description: Remove Assistant Tag
       operationId: remove_assistant_tag
       parameters:
       - description: Unique identifier of the assistant.
@@ -72043,7 +76322,6 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tools/{tool_id}:
     delete:
-      description: Remove Assistant Tool
       operationId: remove_assistant_tool
       parameters:
       - description: Unique identifier of the assistant.
@@ -72077,7 +76355,6 @@ paths:
       - Assistants
       x-latency-category: responsive
     put:
-      description: Add Assistant Tool
       operationId: add_assistant_tool
       parameters:
       - description: Unique identifier of the assistant.
@@ -72407,7 +76684,6 @@ paths:
       x-latency-category: responsive
   /ai/clusters:
     get:
-      description: List all clusters
       operationId: list_all_requested_clusters_public_text_clusters_get
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -72474,7 +76750,6 @@ paths:
       x-latency-category: responsive
   /ai/clusters/{task_id}:
     delete:
-      description: Delete a cluster
       operationId: delete_cluster_by_task_id_public_text_clusters__task_id__delete
       parameters:
       - description: Unique identifier of the task.
@@ -72498,7 +76773,6 @@ paths:
       - Clusters
       x-latency-category: responsive
     get:
-      description: Fetch a cluster
       operationId: fetch_cluster_by_task_id_public_text_clusters__task_id__get
       parameters:
       - description: Unique identifier of the task.
@@ -72545,7 +76819,6 @@ paths:
       x-latency-category: responsive
   /ai/clusters/{task_id}/graph:
     get:
-      description: Fetch a cluster visualization
       operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_id__image_get
       parameters:
       - description: Unique identifier of the task.
@@ -75854,7 +80127,6 @@ paths:
       x-latency-category: responsive
   /ai/tools:
     get:
-      description: List Tools
       operationId: list_tools
       parameters:
       - description: Filter results by filter type.
@@ -75908,7 +80180,6 @@ paths:
       - Assistants
       x-latency-category: responsive
     post:
-      description: Create Tool
       operationId: create_tool_post
       requestBody:
         content:
@@ -75935,7 +80206,6 @@ paths:
       x-latency-category: responsive
   /ai/tools/{tool_id}:
     delete:
-      description: Delete Tool
       operationId: delete_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -75962,7 +80232,6 @@ paths:
       - Assistants
       x-latency-category: responsive
     get:
-      description: Get Tool
       operationId: get_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -75990,7 +80259,6 @@ paths:
       - Assistants
       x-latency-category: responsive
     patch:
-      description: Update Tool
       operationId: update_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -76051,18 +80319,7 @@ paths:
           type: integer
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/AlphanumericSenderId'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
-          description: Successful response with a list of alphanumeric sender IDs.
+          $ref: '#/components/responses/ListAlphanumericSenderIdsResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '422':
@@ -76083,14 +80340,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/AlphanumericSenderId'
-                type: object
-          description: Successful response with a single alphanumeric sender ID.
+          $ref: '#/components/responses/AlphanumericSenderIdResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '422':
@@ -76113,14 +80363,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/AlphanumericSenderId'
-                type: object
-          description: Successful response with a single alphanumeric sender ID.
+          $ref: '#/components/responses/AlphanumericSenderIdResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '404':
@@ -76141,14 +80384,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/AlphanumericSenderId'
-                type: object
-          description: Successful response with a single alphanumeric sender ID.
+          $ref: '#/components/responses/AlphanumericSenderIdResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '404':
@@ -76168,11 +80404,7 @@ paths:
       - $ref: '#/components/parameters/Sort'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuditLogList'
-          description: A list of audit log entries.
+          $ref: '#/components/responses/AuditLogListResponse'
         '401':
           $ref: '#/components/responses/AuditLogsGenericErrorResponse'
         default:
@@ -76459,7 +80691,6 @@ paths:
       x-latency-category: responsive
   /available_phone_number_blocks:
     get:
-      description: List available phone number blocks
       operationId: ListAvailablePhoneNumberBlocks
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -76492,20 +80723,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/AvailablePhoneNumberBlock'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
-                title: List Available Phone Numbers Blocks Response
-                type: object
-          description: Successful response with a list of available phone numbers
-            blocks.
+          $ref: '#/components/responses/ListAvailablePhoneNumbersBlockResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -76522,7 +80740,6 @@ paths:
       x-latency-category: responsive
   /available_phone_numbers:
     get:
-      description: List available phone numbers
       operationId: ListAvailablePhoneNumbers
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -76614,21 +80831,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/AvailablePhoneNumber'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
-                  metadata:
-                    $ref: '#/components/schemas/AvailablePhoneNumbersMetadata'
-                title: List Available Phone Numbers Response
-                type: object
-          description: Successful response with a list of available phone numbers.
+          $ref: '#/components/responses/ListAvailablePhoneNumbersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -76647,18 +80850,10 @@ paths:
       x-latency-category: responsive
   /balance:
     get:
-      description: Get user balance details
       operationId: GetUserBalance
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UserBalance'
-                type: object
-          description: Get user balance details
+          $ref: '#/components/responses/UserBalanceResponse'
         '403':
           $ref: '#/components/responses/billing_ForbiddenErrorResponse'
         '422':
@@ -76674,7 +80869,7 @@ paths:
   /billing_groups:
     get:
       deprecated: false
-      description: List all billing groups
+      description: ''
       operationId: ListBillingGroups
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -76722,7 +80917,7 @@ paths:
       x-latency-category: responsive
     post:
       deprecated: false
-      description: Create a billing group
+      description: ''
       operationId: CreateBillingGroup
       requestBody:
         content:
@@ -76756,7 +80951,7 @@ paths:
   /billing_groups/{id}:
     delete:
       deprecated: false
-      description: Delete a billing group
+      description: ''
       operationId: DeleteBillingGroup
       parameters:
       - description: The id of the billing group
@@ -76794,7 +80989,7 @@ paths:
       x-latency-category: responsive
     get:
       deprecated: false
-      description: Get a billing group
+      description: ''
       operationId: GetBillingGroup
       parameters:
       - description: The id of the billing group
@@ -76828,7 +81023,7 @@ paths:
       x-latency-category: responsive
     patch:
       deprecated: false
-      description: Update a billing group
+      description: ''
       operationId: UpdateBillingGroup
       parameters:
       - description: The id of the billing group
@@ -76892,18 +81087,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/BulkSIMCardActionDetailed'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/BulkSIMCardActionCollectionResponse'
         '401':
           description: Unauthorized
         default:
@@ -76922,14 +81106,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkSIMCardActionDetailed'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/BulkSIMCardActionDetailedResponse'
         '401':
           description: Unauthorized
         default:
@@ -77152,19 +81329,7 @@ paths:
       - $ref: '#/components/parameters/SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CallControlApplication'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Call Control Applications Response
-                type: object
-          description: Successful response with a list of call control applications.
+          $ref: '#/components/responses/ListCallControlApplicationsResponse'
         '400':
           description: Bad request
         '401':
@@ -77189,15 +81354,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlApplication'
-                title: Call Control Application Response
-                type: object
-          description: Successful response with details about a call control application.
+          $ref: '#/components/responses/CallControlApplicationResponse'
         '422':
           description: Bad Request
       summary: Create a call control application
@@ -77220,15 +81377,7 @@ paths:
           x-format: int64
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlApplication'
-                title: Call Control Application Response
-                type: object
-          description: Successful response with details about a call control application.
+          $ref: '#/components/responses/CallControlApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -77253,15 +81402,7 @@ paths:
           x-format: int64
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlApplication'
-                title: Call Control Application Response
-                type: object
-          description: Successful response with details about a call control application.
+          $ref: '#/components/responses/CallControlApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -77293,15 +81434,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlApplication'
-                title: Call Control Application Response
-                type: object
-          description: Successful response with details about a call control application.
+          $ref: '#/components/responses/CallControlApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -77328,19 +81461,7 @@ paths:
       - $ref: '#/components/parameters/call-control_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CallEvent'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Call Events Response
-                type: object
-          description: Successful response with a list of call events.
+          $ref: '#/components/responses/ListCallEventsResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77481,16 +81602,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallWithRecordingId'
-                title: Retrieve Call Status Response With Recording ID
-                type: object
-          description: Successful response with details about a call status that includes
-            recording_id.
+          $ref: '#/components/responses/RetrieveCallStatusResponseWithRecordingId'
         '400':
           $ref: '#/components/responses/BadRequestResponse'
         '422':
@@ -77514,15 +81626,7 @@ paths:
       - $ref: '#/components/parameters/CallControlId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Call'
-                title: Retrieve Call Status Response
-                type: object
-          description: Successful response with details about a call status.
+          $ref: '#/components/responses/RetrieveCallStatusResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77547,15 +81651,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77580,16 +81676,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResultWithConversationId'
-                title: Call Control Command Response With Conversation ID
-                type: object
-          description: Successful response upon making a call control command that
-            includes conversation_id.
+          $ref: '#/components/responses/CallControlCommandResponseWithConversationId'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77623,16 +81710,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResultWithConversationId'
-                title: Call Control Command Response With Conversation ID
-                type: object
-          description: Successful response upon making a call control command that
-            includes conversation_id.
+          $ref: '#/components/responses/CallControlCommandResponseWithConversationId'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77656,15 +81734,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77711,16 +81781,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResultWithRecordingId'
-                title: Call Control Command Response With Recording ID
-                type: object
-          description: Successful response upon making a call control command that
-            includes recording_id.
+          $ref: '#/components/responses/CallControlCommandResponseWithRecordingId'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77754,15 +81815,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77786,15 +81839,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77831,15 +81876,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResultWithConversationRelayId'
-                title: Call Control Command Response With Conversation Relay ID
-                type: object
-          description: Successful response upon starting Conversation Relay.
+          $ref: '#/components/responses/CallControlCommandResponseWithConversationRelayId'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77863,15 +81900,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77895,15 +81924,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77932,15 +81953,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -77972,15 +81985,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78018,15 +82023,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78058,15 +82055,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78096,16 +82085,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResultWithConversationId'
-                title: Call Control Command Response With Conversation ID
-                type: object
-          description: Successful response upon making a call control command that
-            includes conversation_id.
+          $ref: '#/components/responses/CallControlCommandResponseWithConversationId'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78150,15 +82130,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78199,15 +82171,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78241,15 +82205,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78274,15 +82230,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78328,15 +82276,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78368,15 +82308,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78409,15 +82341,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78449,15 +82373,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78494,15 +82410,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78534,15 +82442,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78579,15 +82479,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78619,15 +82511,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78660,15 +82544,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78700,15 +82576,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78733,15 +82601,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78773,15 +82633,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78817,15 +82669,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78855,15 +82699,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78895,15 +82731,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78914,7 +82742,6 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/suppression_start:
     post:
-      description: Noise Suppression Start (BETA)
       operationId: noiseSuppressionStart
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -78927,15 +82754,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78946,7 +82765,6 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/suppression_stop:
     post:
-      description: Noise Suppression Stop (BETA)
       operationId: noiseSuppressionStop
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -78959,15 +82777,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -78992,15 +82802,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -79033,15 +82835,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -79065,15 +82859,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -79124,15 +82910,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CallControlCommandResult'
-                title: Call Control Command Response
-                type: object
-          description: Successful response upon making a call control command.
+          $ref: '#/components/responses/CallControlCommandResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -79153,18 +82931,7 @@ paths:
       - $ref: '#/components/parameters/voice-channels_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GcbChannelZone'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: A list of channel zones
+          $ref: '#/components/responses/GetGcbChannelZonesRequestResponse'
         '400':
           description: Bad request
         '401':
@@ -79200,11 +82967,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GcbChannelZone'
-          description: Successfuly patched channel zone
+          $ref: '#/components/responses/PatchGcbChannelZoneRequestResponse'
         '400':
           description: Bad request
         '401':
@@ -79314,7 +83077,6 @@ paths:
       x-latency-category: responsive
   /comments:
     get:
-      description: Retrieve all comments
       operationId: ListComments
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -79339,18 +83101,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Comment'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: An array of Comment Responses
+          $ref: '#/components/responses/listCommentsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -79366,7 +83117,6 @@ paths:
       - Phone Number Orders
       x-latency-category: responsive
     post:
-      description: Create a comment
       operationId: CreateComment
       requestBody:
         content:
@@ -79376,16 +83126,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    allOf:
-                    - $ref: '#/components/schemas/Comment'
-                    - type: object
-                type: object
-          description: A Comment Response
+          $ref: '#/components/responses/CommentResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -79402,7 +83143,6 @@ paths:
       x-latency-category: responsive
   /comments/{id}:
     get:
-      description: Retrieve a comment
       operationId: RetrieveComment
       parameters:
       - description: The comment ID.
@@ -79413,16 +83153,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    allOf:
-                    - $ref: '#/components/schemas/Comment'
-                    - type: object
-                type: object
-          description: A Comment Response
+          $ref: '#/components/responses/CommentResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -79439,7 +83170,6 @@ paths:
       x-latency-category: responsive
   /comments/{id}/read:
     patch:
-      description: Mark a comment as read
       operationId: MarkCommentRead
       parameters:
       - description: The comment ID.
@@ -79450,16 +83180,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    allOf:
-                    - $ref: '#/components/schemas/ReadComment'
-                    - type: object
-                type: object
-          description: A Comment Response
+          $ref: '#/components/responses/ReadCommentResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -79487,19 +83208,7 @@ paths:
       - $ref: '#/components/parameters/call-control_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Conference'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Conferences Response
-                type: object
-          description: Successful response with a list of conferences.
+          $ref: '#/components/responses/ListConferencesResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -79543,15 +83252,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Conference'
-                title: Conference Response
-                type: object
-          description: Successful response with details about a conference.
+          $ref: '#/components/responses/ConferenceResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -79596,19 +83297,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Participant'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Participants Response
-                type: object
-          description: Successful response with a list of conference participants.
+          $ref: '#/components/responses/ListParticipantsResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79633,15 +83322,7 @@ paths:
       - $ref: '#/components/parameters/ConferenceRegion'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Conference'
-                title: Conference Response
-                type: object
-          description: Successful response with details about a conference.
+          $ref: '#/components/responses/ConferenceResponse'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
       summary: Retrieve a conference
@@ -79667,15 +83348,7 @@ paths:
               $ref: '#/components/schemas/EndConferenceRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79707,15 +83380,7 @@ paths:
               $ref: '#/components/schemas/ConferenceGatherUsingAudioRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79746,15 +83411,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79790,15 +83447,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -79828,15 +83477,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -79864,15 +83505,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79902,15 +83535,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79940,15 +83565,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -79978,15 +83595,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80023,15 +83632,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80070,15 +83671,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80108,15 +83701,7 @@ paths:
               $ref: '#/components/schemas/ConferenceSendDTMFRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80147,15 +83732,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80186,15 +83763,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80224,15 +83793,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80262,15 +83823,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -80301,15 +83854,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ConferenceCommandResult'
-                title: Conference Command Response
-                type: object
-          description: Successful response upon making a conference command.
+          $ref: '#/components/responses/ConferenceCommandResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -80405,19 +83950,7 @@ paths:
       - $ref: '#/components/parameters/connections_SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Connection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List Connections Response
-                type: object
-          description: Successful response with a list of connections.
+          $ref: '#/components/responses/ListConnectionsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80443,19 +83976,7 @@ paths:
       - $ref: '#/components/parameters/call-control_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ActiveCall'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/CursorPaginationMeta'
-                title: Active Calls Response
-                type: object
-          description: Successful response with list of details about active calls.
+          $ref: '#/components/responses/ActiveCallsResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntityResponse'
         default:
@@ -80480,15 +84001,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Connection'
-                title: Connection Response
-                type: object
-          description: Successful response with details about a connection.
+          $ref: '#/components/responses/ConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80507,101 +84020,7 @@ paths:
       operationId: retreiveCountryCoverage
       responses:
         '200':
-          content:
-            application/json:
-              examples:
-                example-1:
-                  value:
-                    data:
-                      Afghanistan:
-                        code: AF
-                        features: []
-                        international_sms: false
-                        inventory_coverage: false
-                        local: {}
-                        mobile: {}
-                        national: {}
-                        numbers: false
-                        p2p: false
-                        phone_number_type: []
-                        quickship: false
-                        region: null
-                        reservable: false
-                        toll_free: {}
-                      Aland Islands:
-                        code: AX
-                        features: []
-                        international_sms: false
-                        inventory_coverage: false
-                        local: {}
-                        mobile: {}
-                        national: {}
-                        numbers: false
-                        p2p: false
-                        phone_number_type: []
-                        quickship: false
-                        region: null
-                        reservable: false
-                        toll_free: {}
-                      Albania:
-                        code: AL
-                        features:
-                        - voice
-                        - fax
-                        international_sms: false
-                        inventory_coverage: false
-                        local:
-                          features:
-                          - fax
-                          - voice
-                          full_pstn_replacement: false
-                          international_sms: false
-                          p2p: false
-                          quickship: false
-                          reservable: false
-                        mobile: {}
-                        national: {}
-                        numbers: true
-                        p2p: false
-                        phone_number_type:
-                        - local
-                        - toll_free
-                        quickship: false
-                        region: EMEA
-                        reservable: false
-                        shared_cost: {}
-                        toll_free:
-                          features:
-                          - fax
-                          - voice
-                          full_pstn_replacement: false
-                          international_sms: false
-                          p2p: false
-                          quickship: false
-                          reservable: false
-                      Algeria:
-                        code: DZ
-                        features: []
-                        international_sms: false
-                        inventory_coverage: false
-                        local: {}
-                        mobile: {}
-                        national: {}
-                        numbers: false
-                        p2p: false
-                        phone_number_type: []
-                        quickship: false
-                        region: null
-                        reservable: false
-                        toll_free: {}
-              schema:
-                properties:
-                  data:
-                    additionalProperties:
-                      $ref: '#/components/schemas/CountryCoverage'
-                    type: object
-                type: object
-          description: Response for country coverage
+          $ref: '#/components/responses/CountryCoverageResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -80630,14 +84049,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CountryCoverage'
-                type: object
-          description: Response for specific country coverage
+          $ref: '#/components/responses/SpecificCountryResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -80662,19 +84074,7 @@ paths:
       - $ref: '#/components/parameters/connections_SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CredentialConnection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List Credential Connections Response
-                type: object
-          description: Successful response with a list of credential connections.
+          $ref: '#/components/responses/ListCredentialConnectionsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80700,15 +84100,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CredentialConnection'
-                title: Credential Connection Response
-                type: object
-          description: Successful response with details about a credential connection.
+          $ref: '#/components/responses/CredentialConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -80733,15 +84125,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CredentialConnection'
-                title: Credential Connection Response
-                type: object
-          description: Successful response with details about a credential connection.
+          $ref: '#/components/responses/CredentialConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80766,15 +84150,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CredentialConnection'
-                title: Credential Connection Response
-                type: object
-          description: Successful response with details about a credential connection.
+          $ref: '#/components/responses/CredentialConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80806,15 +84182,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CredentialConnection'
-                title: Credential Connection Response
-                type: object
-          description: Successful response with details about a credential connection.
+          $ref: '#/components/responses/CredentialConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -80841,66 +84209,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    example:
-                      ip_address: 190.106.106.121
-                      last_registration: '2021-09-28T15:11:02'
-                      port: 37223
-                      record_type: registration_status
-                      sip_username: rogerp
-                      status: Expired
-                      transport: UDP
-                      user_agent: Z 5.4.12 v2.10.13.2-mod
-                    properties:
-                      ip_address:
-                        description: The ip used during the SIP connection
-                        example: 190.106.106.121
-                        type: string
-                      last_registration:
-                        description: ISO 8601 formatted date indicating when the resource
-                          was last updated.
-                        example: '2018-02-02T22:25:27.521Z'
-                        type: string
-                      port:
-                        description: The port of the SIP connection
-                        example: 37223
-                        type: integer
-                      record_type:
-                        description: Identifies the type of the resource.
-                        example: registration_status
-                        type: string
-                      sip_username:
-                        description: The user name of the SIP connection
-                        example: sip_username
-                        type: string
-                      status:
-                        description: The current registration status of your SIP connection
-                        enum:
-                        - Not Applicable
-                        - Not Registered
-                        - Failed
-                        - Expired
-                        - Registered
-                        - Unregistered
-                        type: string
-                      transport:
-                        description: The protocol of the SIP connection
-                        example: TCP
-                        type: string
-                      user_agent:
-                        description: The user agent of the SIP connection
-                        example: Z 5.4.12 v2.10.13.2-mod
-                        type: string
-                    title: Registration Status
-                    type: object
-                title: Registration Status Response
-                type: object
-          description: Successful response with details about a credential connection
-            registration status.
+          $ref: '#/components/responses/RegistrationStatusResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -80940,11 +84249,7 @@ paths:
       - $ref: '#/components/parameters/call-recordings_ConnectionId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialsResponse'
-          description: A response containing a credentials resource.
+          $ref: '#/components/responses/CredentialsResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -80964,11 +84269,7 @@ paths:
         $ref: '#/components/requestBodies/CreateCredentialsRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialsResponse'
-          description: A response containing a credentials resource.
+          $ref: '#/components/responses/CredentialsResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -80988,11 +84289,7 @@ paths:
         $ref: '#/components/requestBodies/CreateCredentialsRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CredentialsResponse'
-          description: A response containing a credentials resource.
+          $ref: '#/components/responses/CredentialsResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -81029,18 +84326,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CustomerServiceRecord'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/ListCustomerServiceRecords'
         '401':
           $ref: '#/components/responses/customer_service_record_UnauthorizedErrorResponse'
         '403':
@@ -81060,24 +84346,7 @@ paths:
         $ref: '#/components/requestBodies/CreateCustomerServiceRecord'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    created_at: '2023-01-01T00:00:00Z'
-                    error_message: null
-                    id: db7cebdb-21a8-4e89-8f51-e03ba6b799bb
-                    phone_number: '+2003271000'
-                    result: null
-                    status: pending
-                    updated_at: '2023-01-01T00:00:00Z'
-                    webhook_url: https://example.com/webhook
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CustomerServiceRecord'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateCustomerServiceRecord'
         '401':
           $ref: '#/components/responses/customer_service_record_UnauthorizedErrorResponse'
         '403':
@@ -81098,16 +84367,7 @@ paths:
         $ref: '#/components/requestBodies/VerifyCustomerServiceRecordPhoneNumberCoverage'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CustomerServiceRecordPhoneNumberCoverage'
-                    type: array
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/ListCustomerServiceRecordPhoneNumberCoverage'
         '401':
           $ref: '#/components/responses/customer_service_record_UnauthorizedErrorResponse'
         '403':
@@ -81128,14 +84388,7 @@ paths:
       - $ref: '#/components/parameters/PathCustomerServiceRecordId'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CustomerServiceRecord'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/ShowCustomerServiceRecord'
         '401':
           $ref: '#/components/responses/customer_service_record_UnauthorizedErrorResponse'
         '403':
@@ -81372,12 +84625,7 @@ paths:
       - $ref: '#/components/parameters/media-streaming_ConnectionId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DialogflowConnectionResponse'
-          description: Return details of the Dialogflow connection associated with
-            the given CallControl connection.
+          $ref: '#/components/responses/DialogflowConnectionResponseBody'
         '404':
           $ref: '#/components/responses/media-streaming_NotFoundResponse'
         default:
@@ -81396,12 +84644,7 @@ paths:
         $ref: '#/components/requestBodies/DialogflowConnectionRequest'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DialogflowConnectionResponse'
-          description: Return details of the Dialogflow connection associated with
-            the given CallControl connection.
+          $ref: '#/components/responses/DialogflowConnectionResponseBody'
         '422':
           $ref: '#/components/responses/media-streaming_UnprocessableEntityResponse'
         default:
@@ -81419,12 +84662,7 @@ paths:
         $ref: '#/components/requestBodies/DialogflowConnectionRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DialogflowConnectionResponse'
-          description: Return details of the Dialogflow connection associated with
-            the given CallControl connection.
+          $ref: '#/components/responses/DialogflowConnectionResponseBody'
         '404':
           $ref: '#/components/responses/media-streaming_NotFoundResponse'
         '422':
@@ -82012,18 +85250,7 @@ paths:
       - $ref: '#/components/parameters/documents_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DocServiceDocumentLink'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListDocServiceDocumentLinksResponse'
         '422':
           content:
             application/json:
@@ -82047,18 +85274,7 @@ paths:
       - $ref: '#/components/parameters/documents_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DocServiceDocument'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListDocServiceDocumentsResponse'
         '422':
           content:
             application/json:
@@ -82087,14 +85303,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocServiceDocument'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocServiceDocumentResponse'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
         default:
@@ -82113,14 +85322,7 @@ paths:
       - $ref: '#/components/parameters/Id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocServiceDocument'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocServiceDocumentResponse'
         '422':
           content:
             application/json:
@@ -82141,14 +85343,7 @@ paths:
       - $ref: '#/components/parameters/Id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocServiceDocument'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocServiceDocumentResponse'
         '422':
           content:
             application/json:
@@ -82175,14 +85370,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocServiceDocument'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocServiceDocumentResponse'
         '422':
           content:
             application/json:
@@ -82204,12 +85392,7 @@ paths:
       - $ref: '#/components/parameters/Id'
       responses:
         '200':
-          content:
-            '*':
-              schema:
-                format: binary
-                type: string
-          description: Successful response
+          $ref: '#/components/responses/DownloadDocServiceDocumentResponse'
         '422':
           content:
             application/json:
@@ -82295,18 +85478,7 @@ paths:
       - $ref: '#/components/parameters/emergency_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DynamicEmergencyAddress'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/Metadata'
-                type: object
-          description: Dynamic Emergency Address Responses
+          $ref: '#/components/responses/listDynamicEmergencyAddresses'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82332,14 +85504,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyAddress'
-                type: object
-          description: Dynamic Emergency Address Response
+          $ref: '#/components/responses/DynamicEmergencyAddressResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82368,14 +85533,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyAddress'
-                type: object
-          description: Dynamic Emergency Address Response
+          $ref: '#/components/responses/DynamicEmergencyAddressResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82403,14 +85561,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyAddress'
-                type: object
-          description: Dynamic Emergency Address Response
+          $ref: '#/components/responses/DynamicEmergencyAddressResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82452,18 +85603,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DynamicEmergencyEndpoint'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/Metadata'
-                type: object
-          description: Dynamic Emergency Endpoints Responses
+          $ref: '#/components/responses/listDynamicEmergencyEndpoints'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82489,14 +85629,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyEndpoint'
-                type: object
-          description: Dynamic Emergency Endpoint Response
+          $ref: '#/components/responses/DynamicEmergencyEndpointResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82525,14 +85658,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyEndpoint'
-                type: object
-          description: Dynamic Emergency Endpoint Response
+          $ref: '#/components/responses/DynamicEmergencyEndpointResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -82560,14 +85686,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DynamicEmergencyEndpoint'
-                type: object
-          description: Dynamic Emergency Endpoint Response
+          $ref: '#/components/responses/DynamicEmergencyEndpointResponse'
         '400':
           $ref: '#/components/responses/emergency_BadRequestResponse'
         '401':
@@ -83574,19 +86693,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ExternalConnection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
-                title: Get All External Connections Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllExternalConnectionResponse'
         '400':
           description: Bad request
         '401':
@@ -83614,15 +86721,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnection'
-                title: External Connection Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ExternalConnectionResponse'
         '422':
           description: Bad request
       summary: Creates an External Connection
@@ -83640,19 +86739,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  log_messages:
-                    items:
-                      $ref: '#/components/schemas/LogMessage'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
-                title: List Log Messages Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListLogMessagesResponse'
         '401':
           description: Unauthorized
         '422':
@@ -83696,19 +86783,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  log_messages:
-                    items:
-                      $ref: '#/components/schemas/LogMessage'
-                    maxItems: 1
-                    minItems: 1
-                    type: array
-                title: Get Log Message Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetLogMessageResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83728,15 +86803,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnection'
-                title: External Connection Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ExternalConnectionResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83755,15 +86822,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnection'
-                title: External Connection Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ExternalConnectionResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83789,15 +86848,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnection'
-                title: External Connection Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ExternalConnectionResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83817,17 +86868,7 @@ paths:
       - $ref: '#/components/parameters/FilterCivicAddressesConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CivicAddress'
-                    type: array
-                title: Get All Civic Addresses Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllCivicAddressesResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83850,15 +86891,7 @@ paths:
       - $ref: '#/components/parameters/address_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CivicAddress'
-                title: Get Civic Address Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetCivicAddressResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83873,7 +86906,6 @@ paths:
       x-latency-category: responsive
   /external_connections/{id}/locations/{location_id}:
     patch:
-      description: Update a location's static emergency address
       operationId: updateLocation
       parameters:
       - description: The ID of the external connection
@@ -83946,19 +86978,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ExternalConnectionPhoneNumber'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
-                title: List External Connection Phone Numbers Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListExternalConnectionPhoneNumbersResponse'
         '401':
           description: Unauthorized
         '404':
@@ -83979,15 +86999,7 @@ paths:
       - $ref: '#/components/parameters/phone_number_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnectionPhoneNumber'
-                title: Get External Connection Phone Number Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetExternalConnectionPhoneNumberResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84012,15 +87024,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ExternalConnectionPhoneNumber'
-                title: Get External Connection Phone Number Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetExternalConnectionPhoneNumberResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84043,19 +87047,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Release'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
-                title: List Releases Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListReleasesResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84075,15 +87067,7 @@ paths:
       - $ref: '#/components/parameters/release_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Release'
-                title: Get Release Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetReleaseResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84102,19 +87086,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Upload'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/external-voice-integrations_PaginationMeta'
-                title: List Uploads Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListUploadsResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84209,24 +87181,7 @@ paths:
       - $ref: '#/components/parameters/external-voice-integrations_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      pending_numbers_count:
-                        description: The count of phone numbers that are pending assignment
-                          to the external connection.
-                        type: integer
-                      pending_orders_count:
-                        description: The count of number uploads that have not yet
-                          been uploaded to Microsoft.
-                        type: integer
-                    type: object
-                title: Get Uploads Status Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetUploadsStatusResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84244,15 +87199,7 @@ paths:
       - $ref: '#/components/parameters/ticket_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Upload'
-                title: Get Upload Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetUploadResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84274,15 +87221,7 @@ paths:
       - $ref: '#/components/parameters/ticket_id'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Upload'
-                title: Get Upload Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetUploadResponse'
         '401':
           description: Unauthorized
         '404':
@@ -84308,19 +87247,7 @@ paths:
       - $ref: '#/components/parameters/programmable-fax_SortApplication'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/FaxApplication'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: Get All Fax Applications Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllFaxApplicationsResponse'
         '400':
           $ref: '#/components/responses/programmable-fax_BadRequestResponse'
         '401':
@@ -84348,15 +87275,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FaxApplication'
-                title: Fax Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/FaxApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84377,15 +87296,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FaxApplication'
-                title: Fax Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/FaxApplicationResponse'
         '400':
           $ref: '#/components/responses/programmable-fax_BadRequestResponse'
         '401':
@@ -84406,15 +87317,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FaxApplication'
-                title: Fax Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/FaxApplicationResponse'
         '400':
           $ref: '#/components/responses/programmable-fax_BadRequestResponse'
         '401':
@@ -84442,15 +87345,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FaxApplication'
-                title: Fax Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/FaxApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84465,7 +87360,7 @@ paths:
       x-latency-category: responsive
   /faxes:
     get:
-      description: View a list of faxes
+      description: ''
       operationId: ListFaxes
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -84552,19 +87447,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Fax'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Faxes Response
-                type: object
-          description: List faxes response
+          $ref: '#/components/responses/ListFaxesResponse'
         '404':
           $ref: '#/components/responses/programmable-fax_NotFoundResponse'
         default:
@@ -84624,15 +87507,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fax'
-                title: Send Fax Response
-                type: object
-          description: Send fax response
+          $ref: '#/components/responses/SendFaxResponse'
         '422':
           $ref: '#/components/responses/programmable-fax_UnprocessableEntityResponse'
         default:
@@ -84643,7 +87518,6 @@ paths:
       x-latency-category: responsive
   /faxes/{id}:
     delete:
-      description: Delete a fax
       operationId: DeleteFax
       parameters:
       - description: The unique identifier of a fax.
@@ -84665,7 +87539,6 @@ paths:
       - Programmable Fax Commands
       x-latency-category: responsive
     get:
-      description: View a fax
       operationId: ViewFax
       parameters:
       - description: The unique identifier of a fax.
@@ -84677,15 +87550,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fax'
-                title: Get Fax Response
-                type: object
-          description: Get fax response
+          $ref: '#/components/responses/GetFaxResponse'
         '404':
           $ref: '#/components/responses/programmable-fax_NotFoundResponse'
         default:
@@ -84709,22 +87574,7 @@ paths:
           type: string
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    result: ok
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                title: Successful response upon accepting cancel fax command
-                type: object
-          description: Successful response upon accepting cancel fax command
+          $ref: '#/components/responses/CancelFaxResponse'
         '404':
           $ref: '#/components/responses/programmable-fax_NotFoundResponse'
         '422':
@@ -84749,22 +87599,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    result: ok
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                title: Refresh Fax Response
-                type: object
-          description: Refresh fax response
+          $ref: '#/components/responses/RefreshFaxResponse'
         '404':
           $ref: '#/components/responses/programmable-fax_NotFoundResponse'
         default:
@@ -84783,19 +87618,7 @@ paths:
       - $ref: '#/components/parameters/connections_SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/FqdnConnection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List FQDN Connections Response
-                type: object
-          description: Successful response with a list of FQDN connections.
+          $ref: '#/components/responses/ListFqdnConnectionsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -84823,15 +87646,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FqdnConnection'
-                title: FQDN Connection Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84853,15 +87668,7 @@ paths:
       - $ref: '#/components/parameters/connections_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FqdnConnection'
-                title: FQDN Connection Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84881,15 +87688,7 @@ paths:
       - $ref: '#/components/parameters/connections_id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FqdnConnection'
-                title: FQDN Connection Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84916,15 +87715,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/FqdnConnection'
-                title: FQDN Connection Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -84969,19 +87760,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Fqdn'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List FQDNs Response
-                type: object
-          description: Successful response with a list of FQDN connections.
+          $ref: '#/components/responses/ListFqdnsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -85002,15 +87781,7 @@ paths:
               $ref: '#/components/schemas/CreateFqdnRequest'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fqdn'
-                title: FQDN Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -85030,15 +87801,7 @@ paths:
       - $ref: '#/components/parameters/FqdnId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fqdn'
-                title: FQDN Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -85058,15 +87821,7 @@ paths:
       - $ref: '#/components/parameters/FqdnId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fqdn'
-                title: FQDN Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -85091,15 +87846,7 @@ paths:
               $ref: '#/components/schemas/UpdateFqdnRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Fqdn'
-                title: FQDN Response
-                type: object
-          description: Successful response with details about an FQDN connection.
+          $ref: '#/components/responses/FqdnResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -85118,16 +87865,7 @@ paths:
       operationId: ListGlobalIpAllowedPorts
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIPAllowedPort'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAllowedPortListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85139,7 +87877,6 @@ paths:
   /global_ip_assignment_health:
     description: Global IP Assignment Health Check Metrics over time
     get:
-      description: Global IP Assignment Health Check Metrics
       operationId: GetGlobalIpAssignmentHealth
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85177,16 +87914,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpAssignmentHealthMetric'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85203,18 +87931,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpAssignment'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85234,14 +87951,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIpAssignment'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -85258,14 +87968,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIpAssignment'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85281,14 +87984,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIpAssignment'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85310,14 +88006,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIpAssignment'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85329,7 +88018,6 @@ paths:
   /global_ip_assignments_usage:
     description: Global IP Assignment Usage Metrics over time
     get:
-      description: Global IP Assignment Usage Metrics
       operationId: GetGlobalIpAssignmentUsage
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85367,16 +88055,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpAssignmentUsageMetric'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpAssignmentUsageResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85391,16 +88070,7 @@ paths:
       operationId: ListGlobalIpHealthCheckTypes
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpHealthCheckType'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthCheckTypesResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85417,18 +88087,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIPHealthCheck'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthCheckListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85448,14 +88107,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIPHealthCheck'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthCheckResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -85472,14 +88124,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIPHealthCheck'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthCheckResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85495,14 +88140,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIPHealthCheck'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpHealthCheckResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85514,7 +88152,6 @@ paths:
   /global_ip_latency:
     description: Global IP Latency Metrics over time
     get:
-      description: Global IP Latency Metrics
       operationId: GetGlobalIpLatency
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85540,16 +88177,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpLatencyMetric'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpLatencyResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85564,16 +88192,7 @@ paths:
       operationId: ListGlobalIpProtocols
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIPProtocol'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpProtocolListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85585,7 +88204,6 @@ paths:
   /global_ip_usage:
     description: Global IP Usage Metrics over time
     get:
-      description: Global IP Usage Metrics
       operationId: GetGlobalIpUsage
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85611,16 +88229,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIpUsageMetric'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpUsageResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85637,18 +88246,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/GlobalIP'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85668,14 +88266,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIP'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -85692,14 +88283,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIP'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85715,14 +88299,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GlobalIP'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GlobalIpResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -85874,19 +88451,7 @@ paths:
           type: integer
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/InexplicitNumberOrderResponse'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Inexplicit Number Orders Response
-                type: object
-          description: Successful response with a list of inexplicit number orders.
+          $ref: '#/components/responses/InexplicitNumberOrdersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -85913,16 +88478,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/InexplicitNumberOrderResponse'
-                title: Inexplicit Number Order Response
-                type: object
-          description: Successful response with details about an inexplicit number
-            order.
+          $ref: '#/components/responses/InexplicitNumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -85951,16 +88507,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/InexplicitNumberOrderResponse'
-                title: Inexplicit Number Order Response
-                type: object
-          description: Successful response with details about an inexplicit number
-            order.
+          $ref: '#/components/responses/InexplicitNumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -86311,18 +88858,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/InventoryCoverage'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/InventoryCoverageMetadata'
-                type: object
-          description: Successful response with a list of inventory coverage levels
+          $ref: '#/components/responses/InventoryCoverageResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -86429,14 +88965,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/InvoiceDetail'
-                type: object
-          description: Get invoice details
+          $ref: '#/components/responses/InvoiceDetailResponse'
         '400':
           $ref: '#/components/responses/BadRequestErrorResponse'
         '403':
@@ -86457,19 +88986,7 @@ paths:
       - $ref: '#/components/parameters/connections_SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/IpConnection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List Ip Connections Response
-                type: object
-          description: Successful response with a list of IP connections.
+          $ref: '#/components/responses/ListIpConnectionsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86495,15 +89012,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/IpConnection'
-                title: Ip Connection Response
-                type: object
-          description: Successful response with details about an IP connection.
+          $ref: '#/components/responses/IpConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -86528,15 +89037,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/IpConnection'
-                title: Ip Connection Response
-                type: object
-          description: Successful response with details about an IP connection.
+          $ref: '#/components/responses/IpConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86561,15 +89062,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/IpConnection'
-                title: Ip Connection Response
-                type: object
-          description: Successful response with details about an IP connection.
+          $ref: '#/components/responses/IpConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86601,15 +89094,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/IpConnection'
-                title: Ip Connection Response
-                type: object
-          description: Successful response with details about an IP connection.
+          $ref: '#/components/responses/IpConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -86650,19 +89135,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Ip'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List Ips Response
-                type: object
-          description: Successful response with a list of IPs.
+          $ref: '#/components/responses/ListIpsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86685,15 +89158,7 @@ paths:
               $ref: '#/components/schemas/CreateIpRequest'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Ip'
-                title: Ip Response
-                type: object
-          description: Successful response with details about an IP.
+          $ref: '#/components/responses/IpResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -86713,15 +89178,7 @@ paths:
       - $ref: '#/components/parameters/IpId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Ip'
-                title: Ip Response
-                type: object
-          description: Successful response with details about an IP.
+          $ref: '#/components/responses/IpResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86741,15 +89198,7 @@ paths:
       - $ref: '#/components/parameters/IpId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Ip'
-                title: Ip Response
-                type: object
-          description: Successful response with details about an IP.
+          $ref: '#/components/responses/IpResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -86774,15 +89223,7 @@ paths:
               $ref: '#/components/schemas/UpdateIpRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Ip'
-                title: Ip Response
-                type: object
-          description: Successful response with details about an IP.
+          $ref: '#/components/responses/IpResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -86798,7 +89239,7 @@ paths:
   /ledger_billing_group_reports:
     post:
       deprecated: false
-      description: Create a ledger billing group report
+      description: ''
       operationId: CreateBillingGroupReport
       parameters: []
       requestBody:
@@ -86837,7 +89278,7 @@ paths:
   /ledger_billing_group_reports/{id}:
     get:
       deprecated: false
-      description: Get a ledger billing group report
+      description: ''
       operationId: GetBillingGroupReport
       parameters:
       - description: The id of the ledger billing group report
@@ -87701,39 +90142,7 @@ paths:
       operationId: GetAllNumbersChannelZones
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      properties:
-                        number_of_channels:
-                          example: 7
-                          type: integer
-                        numbers:
-                          items:
-                            properties:
-                              country:
-                                example: FR
-                                type: string
-                              number:
-                                example: '+15554441234'
-                                type: string
-                            type: object
-                          type: array
-                        zone_id:
-                          example: 1653e6a1-4bfd-4857-97c6-6a51e1c34477
-                          type: string
-                        zone_name:
-                          example: Euro channel zone
-                          type: string
-                      type: object
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: A list of numbers using GCB, grouped by channel zone
+          $ref: '#/components/responses/GetGcbNumbersResponse'
         '400':
           description: Bad request
         '401':
@@ -87753,39 +90162,7 @@ paths:
       - $ref: '#/components/parameters/GcbChannelNumberZoneId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      properties:
-                        number_of_channels:
-                          example: 7
-                          type: integer
-                        numbers:
-                          items:
-                            properties:
-                              country:
-                                example: FR
-                                type: string
-                              number:
-                                example: '+15554441234'
-                                type: string
-                            type: object
-                          type: array
-                        zone_id:
-                          example: 1653e6a1-4bfd-4857-97c6-6a51e1c34477
-                          type: string
-                        zone_name:
-                          example: Euro channel zone
-                          type: string
-                      type: object
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: A list of numbers using GCB, grouped by channel zone
+          $ref: '#/components/responses/GetGcbNumbersResponse'
         '400':
           description: Bad request
         '401':
@@ -87808,18 +90185,7 @@ paths:
       - $ref: '#/components/parameters/IncludeCancelledAccounts'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ManagedAccountMultiListing'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response with a list of managed accounts.
+          $ref: '#/components/responses/ListManagedAccountsResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
       summary: Lists accounts managed by the current user.
@@ -87841,15 +90207,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccount'
-                type: object
-          description: Successful response with information about a single managed
-            account.
+          $ref: '#/components/responses/ManagedAccountResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '422':
@@ -87866,15 +90224,7 @@ paths:
       operationId: ListAllocatableGlobalOutboundChannels
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccountsGlobalOutboundChannels'
-                type: object
-          description: Successful response with information about allocatable global
-            outbound channels.
+          $ref: '#/components/responses/ListManagedAccountsAllocatableGlobalOutboundChannelsResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '403':
@@ -87898,15 +90248,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccount'
-                type: object
-          description: Successful response with information about a single managed
-            account.
+          $ref: '#/components/responses/ManagedAccountResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '404':
@@ -87934,15 +90276,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccount'
-                type: object
-          description: Successful response with information about a single managed
-            account.
+          $ref: '#/components/responses/ManagedAccountResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '404':
@@ -87969,15 +90303,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccount'
-                type: object
-          description: Successful response with information about a single managed
-            account.
+          $ref: '#/components/responses/ManagedAccountResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '404':
@@ -88017,15 +90343,7 @@ paths:
         required: false
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ManagedAccount'
-                type: object
-          description: Successful response with information about a single managed
-            account.
+          $ref: '#/components/responses/ManagedAccountResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '404':
@@ -88058,15 +90376,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SingleManagedAccountGlobalOutboundChannels'
-                type: object
-          description: Successful response with information about the allocatable
-            global outbound channels for the given account.
+          $ref: '#/components/responses/UpdateManagedAccountGlobalChannelLimitResponse'
         '401':
           $ref: '#/components/responses/managed-accounts_UnauthorizedResponse'
         '404':
@@ -88100,19 +90410,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MediaResource'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List of media resources response
-                type: object
-          description: A response with a list of media resources
+          $ref: '#/components/responses/ListMediaResponse'
         '401':
           $ref: '#/components/responses/media-storage_GenericErrorResponse'
         default:
@@ -88137,15 +90435,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MediaResource'
-                title: Media resource response
-                type: object
-          description: A response describing a media resource
+          $ref: '#/components/responses/MediaResponse'
         '401':
           $ref: '#/components/responses/media-storage_GenericErrorResponse'
         '422':
@@ -88182,15 +90472,7 @@ paths:
       - $ref: '#/components/parameters/MediaName'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MediaResource'
-                title: Media resource response
-                type: object
-          description: A response describing a media resource
+          $ref: '#/components/responses/MediaResponse'
         '401':
           $ref: '#/components/responses/media-storage_GenericErrorResponse'
         '404':
@@ -88218,15 +90500,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MediaResource'
-                title: Media resource response
-                type: object
-          description: A response describing a media resource
+          $ref: '#/components/responses/MediaResponse'
         '401':
           $ref: '#/components/responses/media-storage_GenericErrorResponse'
         '404':
@@ -88247,12 +90521,7 @@ paths:
       - $ref: '#/components/parameters/MediaName'
       responses:
         '200':
-          content:
-            application/octet-stream:
-              schema:
-                format: binary
-                type: string
-          description: A response describing a media resource
+          $ref: '#/components/responses/MediaDownloadResponse'
         '401':
           $ref: '#/components/responses/media-storage_GenericErrorResponse'
         '404':
@@ -88287,15 +90556,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Send a message
@@ -88400,7 +90661,6 @@ paths:
       x-latency-category: responsive
   /messages/group_mms:
     post:
-      description: Send a group MMS message
       operationId: CreateGroupMmsMessage
       requestBody:
         content:
@@ -88410,15 +90670,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Send a group MMS message
@@ -88427,7 +90679,6 @@ paths:
       x-latency-category: responsive
   /messages/long_code:
     post:
-      description: Send a long code message
       operationId: CreateLongCodeMessage
       requestBody:
         content:
@@ -88437,15 +90688,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Send a long code message
@@ -88454,7 +90697,6 @@ paths:
       x-latency-category: responsive
   /messages/number_pool:
     post:
-      description: Send a message using number pool
       operationId: CreateNumberPoolMessage
       requestBody:
         content:
@@ -88464,15 +90706,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Send a message using number pool
@@ -88481,7 +90715,6 @@ paths:
       x-latency-category: responsive
   /messages/rcs:
     post:
-      description: Send an RCS message
       operationId: SendRCSMessage
       requestBody:
         content:
@@ -88564,15 +90797,7 @@ paths:
         description: Message payload with send_at set
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Schedule a message
@@ -88581,7 +90806,6 @@ paths:
       x-latency-category: responsive
   /messages/short_code:
     post:
-      description: Send a short code message
       operationId: CreateShortCodeMessage
       requestBody:
         content:
@@ -88591,15 +90815,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundMessagePayload'
-                title: Message Response
-                type: object
-          description: Successful response with details about a message.
+          $ref: '#/components/responses/MessageResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Send a short code message
@@ -88608,7 +90824,6 @@ paths:
       x-latency-category: responsive
   /messages/whatsapp:
     post:
-      description: Send a Whatsapp message
       operationId: SendWhatsappMessage
       requestBody:
         content:
@@ -88702,7 +90917,6 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/agents:
     get:
-      description: List all RCS agents
       operationId: ListRCSAgents
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -88721,7 +90935,6 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/agents/{id}:
     get:
-      description: Retrieve an RCS agent
       operationId: GetRCSAgentById
       parameters:
       - description: RCS agent ID
@@ -88744,7 +90957,6 @@ paths:
       - RCS
       x-latency-category: responsive
     patch:
-      description: Modify an RCS agent
       operationId: UpdateRCSAgentById
       parameters:
       - description: RCS agent ID
@@ -88773,7 +90985,6 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/bulk_capabilities:
     post:
-      description: Check RCS capabilities (batch)
       operationId: ListRCSCapabilitiesOfAPhoneNumbersBatch
       requestBody:
         content:
@@ -88795,7 +91006,6 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/capabilities/{agent_id}/{phone_number}:
     get:
-      description: Check RCS capabilities
       operationId: ListRCSCapabilitiesOfAPhoneNumber
       parameters:
       - description: RCS agent ID
@@ -88855,26 +91065,12 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders:
     get:
-      description: List messaging hosted number orders
       operationId: ListMessagingHostedNumberOrders
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with a list of messaging hosted number
-            orders.
+          $ref: '#/components/responses/ListMessagingHostedNumberOrdersResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List messaging hosted number orders
@@ -88883,7 +91079,6 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a messaging hosted number order
       operationId: CreateMessagingHostedNumberOrder
       requestBody:
         content:
@@ -88893,16 +91088,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                title: Retrieve Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with details about a messaging hosted number
-            order.
+          $ref: '#/components/responses/MessagingHostedNumberOrderResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Create a messaging hosted number order
@@ -88911,7 +91097,6 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders/eligibility_numbers_check:
     post:
-      description: Check hosted messaging eligibility
       operationId: CheckEligibilityNumbers
       requestBody:
         content:
@@ -88957,16 +91142,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                title: Retrieve Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with details about a messaging hosted number
-            order.
+          $ref: '#/components/responses/MessagingHostedNumberOrderResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Delete a messaging hosted number order
@@ -88974,7 +91150,6 @@ paths:
       - Hosted Numbers
       x-latency-category: responsive
     get:
-      description: Retrieve a messaging hosted number order
       operationId: GetMessagingHostedNumberOrder
       parameters:
       - description: Identifies the type of resource.
@@ -88985,16 +91160,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                title: Retrieve Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with details about a messaging hosted number
-            order.
+          $ref: '#/components/responses/MessagingHostedNumberOrderResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve a messaging hosted number order
@@ -89003,7 +91169,6 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders/{id}/actions/file_upload:
     post:
-      description: Upload hosted number document
       operationId: UploadMessagingHostedNumberOrderFile
       parameters:
       - description: Identifies the type of resource.
@@ -89025,16 +91190,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                title: Retrieve Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with details about a messaging hosted number
-            order.
+          $ref: '#/components/responses/MessagingHostedNumberOrderResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Upload hosted number document
@@ -89061,16 +91217,7 @@ paths:
         description: Message payload
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ValidationCodes'
-                title: Retrieve Messaging Hosted Number Response
-                type: object
-          description: Successful response with the phone numbers and their respective
-            status of the validation codes.
+          $ref: '#/components/responses/ValidationCodesResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Validate hosted number codes
@@ -89178,7 +91325,6 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_numbers/{id}:
     delete:
-      description: Delete a messaging hosted number
       operationId: DeleteMessagingHostedNumber
       parameters:
       - description: Identifies the type of resource.
@@ -89189,16 +91335,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingHostedNumberOrder'
-                title: Retrieve Messaging Hosted Number Order Response
-                type: object
-          description: Successful response with details about a messaging hosted number
-            order.
+          $ref: '#/components/responses/MessagingHostedNumberOrderResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Delete a messaging hosted number
@@ -89270,7 +91407,6 @@ paths:
       x-latency-category: responsive
   /messaging_numbers_bulk_updates:
     post:
-      description: Bulk update phone number profiles
       operationId: BulkUpdateMessagingSettingsOnPhoneNumbers
       requestBody:
         content:
@@ -89280,16 +91416,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkMessagingSettingsUpdatePhoneNumbers'
-                title: Retrieve bulk update messaging settings Response
-                type: object
-          description: Successful response with details about messaging bulk update
-            phone numbers.
+          $ref: '#/components/responses/BulkMessagingSettingsUpdatePhoneNumbersResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Bulk update phone number profiles
@@ -89298,7 +91425,6 @@ paths:
       x-latency-category: responsive
   /messaging_numbers_bulk_updates/{order_id}:
     get:
-      description: Retrieve bulk update status
       operationId: GetBulkUpdateMessagingSettingsOnPhoneNumbersStatus
       parameters:
       - description: Order ID to verify bulk update status.
@@ -89309,16 +91435,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkMessagingSettingsUpdatePhoneNumbers'
-                title: Retrieve bulk update messaging settings Response
-                type: object
-          description: Successful response with details about messaging bulk update
-            phone numbers.
+          $ref: '#/components/responses/BulkMessagingSettingsUpdatePhoneNumbersResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve bulk update status
@@ -89432,7 +91549,6 @@ paths:
       x-latency-category: responsive
   /messaging_profiles:
     get:
-      description: List messaging profiles
       operationId: ListMessagingProfiles
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -89462,19 +91578,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MessagingProfile'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Profiles Response
-                type: object
-          description: Successful response with a list of messaging profiles.
+          $ref: '#/components/responses/ListMessagingProfilesResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List messaging profiles
@@ -89484,7 +91588,6 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a messaging profile
       operationId: CreateMessagingProfile
       requestBody:
         content:
@@ -89495,15 +91598,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingProfile'
-                title: Messaging Profile Response
-                type: object
-          description: Successful response with details about a messaging profile.
+          $ref: '#/components/responses/MessagingProfileResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Create a messaging profile
@@ -89513,21 +91608,12 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}:
     delete:
-      description: Delete a messaging profile
       operationId: DeleteMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingProfile'
-                title: Messaging Profile Response
-                type: object
-          description: Successful response with details about a messaging profile.
+          $ref: '#/components/responses/MessagingProfileResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Delete a messaging profile
@@ -89535,21 +91621,12 @@ paths:
       - Profiles
       x-latency-category: responsive
     get:
-      description: Retrieve a messaging profile
       operationId: RetrieveMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingProfile'
-                title: Messaging Profile Response
-                type: object
-          description: Successful response with details about a messaging profile.
+          $ref: '#/components/responses/MessagingProfileResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve a messaging profile
@@ -89557,7 +91634,6 @@ paths:
       - Profiles
       x-latency-category: responsive
     patch:
-      description: Update a messaging profile
       operationId: UpdateMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89570,15 +91646,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingProfile'
-                title: Messaging Profile Response
-                type: object
-          description: Successful response with details about a messaging profile.
+          $ref: '#/components/responses/MessagingProfileResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Update a messaging profile
@@ -89599,15 +91667,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MessagingProfile'
-                title: Messaging Profile Response
-                type: object
-          description: Successful response with details about a messaging profile.
+          $ref: '#/components/responses/MessagingProfileResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '404':
@@ -89645,18 +91705,7 @@ paths:
           type: integer
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/AlphanumericSenderId'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
-          description: Successful response with a list of alphanumeric sender IDs.
+          $ref: '#/components/responses/ListAlphanumericSenderIdsResponse'
         '401':
           $ref: '#/components/responses/messaging_UnauthorizedResponse'
         '404':
@@ -89706,27 +91755,13 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}/phone_numbers:
     get:
-      description: List phone numbers associated with a messaging profile
       operationId: ListProfilePhoneNumbers
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Profile Phone Numbers Response
-                type: object
-          description: Successful response with a list of messaging profile phone
-            numbers.
+          $ref: '#/components/responses/ListMessagingProfilePhoneNumbersResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List phone numbers associated with a messaging profile
@@ -89736,27 +91771,13 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}/short_codes:
     get:
-      description: List short codes associated with a messaging profile
       operationId: ListProfileShortCodes
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ShortCode'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Profile Short Codes Response
-                type: object
-          description: Successful response with a list of messaging profile short
-            codes.
+          $ref: '#/components/responses/ListMessagingProfileShortCodesResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List short codes associated with a messaging profile
@@ -89766,7 +91787,6 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{profile_id}/autoresp_configs:
     get:
-      description: List Auto-Response Settings
       operationId: GetAutorespConfigs
       parameters:
       - description: Unique identifier of the profile.
@@ -89861,7 +91881,6 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     post:
-      description: Create auto-response setting
       operationId: CreateAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -89902,7 +91921,6 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}:
     delete:
-      description: Delete Auto-Response Setting
       operationId: DeleteAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -89936,7 +91954,6 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     get:
-      description: Get Auto-Response Setting
       operationId: GetAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -89979,7 +91996,6 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     put:
-      description: Update Auto-Response Setting
       operationId: UpdateAutoRespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -90268,25 +92284,12 @@ paths:
       x-latency-category: responsive
   /messaging_url_domains:
     get:
-      description: List messaging URL domains
       operationId: ListMessagingUrlDomains
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MessagingUrlDomain'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Profile Url Domains Response
-                type: object
-          description: Successful response with details about a messaging URL domain.
+          $ref: '#/components/responses/ListMessagingUrlDomains'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List messaging URL domains
@@ -90307,18 +92310,7 @@ paths:
       - $ref: '#/components/parameters/wireless_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MobileNetworkOperator'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SearchMobileNetworkOperatorsResponse'
         '401':
           description: Unauthorized
         default:
@@ -90329,26 +92321,12 @@ paths:
       x-latency-category: responsive
   /mobile_phone_numbers/messaging:
     get:
-      description: List mobile phone numbers with messaging settings
       operationId: ListMobilePhoneNumbersWithMessagingSettings
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/MobilePhoneNumberWithMessagingSettings'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Settings Response
-                type: object
-          description: Successful response with a list of mobile phone numbers with
-            messaging settings.
+          $ref: '#/components/responses/MobileListPhoneNumbersWithMessagingSettingsResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List mobile phone numbers with messaging settings
@@ -90358,7 +92336,6 @@ paths:
       x-latency-category: responsive
   /mobile_phone_numbers/{id}/messaging:
     get:
-      description: Retrieve a mobile phone number with messaging settings
       operationId: GetMobilePhoneNumberMessagingSettings
       parameters:
       - description: Identifies the type of resource.
@@ -90369,15 +92346,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/MobilePhoneNumberWithMessagingSettings'
-                title: Retrieve Mobile Messaging Settings Response
-                type: object
-          description: Successful response with details about a mobile phone number.
+          $ref: '#/components/responses/MobilePhoneNumberWithMessagingSettingsResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve a mobile phone number with messaging settings
@@ -90598,18 +92567,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NetworkCoverage'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkCoverageListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90639,18 +92597,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Network'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90670,14 +92617,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Network'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -90694,14 +92634,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Network'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90717,14 +92650,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Network'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90746,14 +92672,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Network'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90770,18 +92689,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DefaultGateway'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DefaultGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90797,18 +92705,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DefaultGateway'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DefaultGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90830,18 +92727,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/DefaultGateway'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DefaultGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -90879,18 +92765,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NetworkInterface'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NetworkInterfaceListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -91417,19 +93292,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NumberBlockOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Number Block Orders Response
-                type: object
-          description: Successful response with a list of number block orders.
+          $ref: '#/components/responses/ListNumberBlockOrdersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91455,15 +93318,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberBlockOrder'
-                title: Number Block Order Response
-                type: object
-          description: Successful response with details about a number block order.
+          $ref: '#/components/responses/NumberBlockOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91491,15 +93346,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberBlockOrder'
-                title: Number Block Order Response
-                type: object
-          description: Successful response with details about a number block order.
+          $ref: '#/components/responses/NumberBlockOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91523,15 +93370,7 @@ paths:
       - $ref: '#/components/parameters/NumberLookupType'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberLookupRecord'
-                title: Number Lookup Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/NumberLookupResponse'
         '422':
           $ref: '#/components/responses/number-lookup_UnprocessableEntity'
         default:
@@ -91560,19 +93399,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NumberOrderPhoneNumber'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Number Order Phone Numbers Response
-                type: object
-          description: Successful response with a list of number order phone numbers.
+          $ref: '#/components/responses/ListNumberOrderPhoneNumbersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91589,7 +93416,6 @@ paths:
       x-latency-category: responsive
   /number_order_phone_numbers/{id}/requirement_group:
     post:
-      description: Update requirement group for a phone number order
       operationId: updateNumberOrderPhoneNumberRequirementGroup
       parameters:
       - description: The unique identifier of the number order phone number
@@ -91649,16 +93475,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberOrderPhoneNumber'
-                title: Number Order Phone Number Response
-                type: object
-          description: Successful response with details about a number order phone
-            number.
+          $ref: '#/components/responses/NumberOrderPhoneNumberResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91692,16 +93509,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberOrderPhoneNumber'
-                title: Number Order Phone Number Response
-                type: object
-          description: Successful response with details about a number order phone
-            number.
+          $ref: '#/components/responses/NumberOrderPhoneNumberResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91757,19 +93565,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NumberOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Number Orders Response
-                type: object
-          description: Successful response with a list of number orders.
+          $ref: '#/components/responses/ListNumberOrdersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91797,15 +93593,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberOrderWithPhoneNumbers'
-                title: Number Order Response
-                type: object
-          description: Successful response with details about a number order.
+          $ref: '#/components/responses/NumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91834,15 +93622,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberOrderWithPhoneNumbers'
-                title: Number Order Response
-                type: object
-          description: Successful response with details about a number order.
+          $ref: '#/components/responses/NumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91875,15 +93655,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberOrderWithPhoneNumbers'
-                title: Number Order Response
-                type: object
-          description: Successful response with details about a number order.
+          $ref: '#/components/responses/NumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91936,19 +93708,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/NumberReservation'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Number Reservations Response
-                type: object
-          description: Successful response with a list of number reservations.
+          $ref: '#/components/responses/ListNumberReservationsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -91975,15 +93735,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberReservation'
-                title: Number Reservation Response
-                type: object
-          description: Successful response with details about a number reservation.
+          $ref: '#/components/responses/NumberReservationResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -92011,15 +93763,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberReservation'
-                title: Number Reservation Response
-                type: object
-          description: Successful response with details about a number reservation.
+          $ref: '#/components/responses/NumberReservationResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -92047,15 +93791,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/NumberReservation'
-                title: Number Reservation Response
-                type: object
-          description: Successful response with details about a number reservation.
+          $ref: '#/components/responses/NumberReservationResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -92836,19 +94572,7 @@ paths:
       - $ref: '#/components/parameters/IncludeGroups'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/OrganizationUser'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/users_PaginationMeta'
-                title: List Organization Users Response
-                type: object
-          description: Successful response with a list of organization users.
+          $ref: '#/components/responses/ListOrganizationUsersResponse'
         '400':
           $ref: '#/components/responses/users_BadRequestResponse'
         '401':
@@ -92882,50 +94606,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              example:
-                data:
-                - created_at: '2018-02-02T22:25:27.521Z'
-                  email: user@example.com
-                  groups:
-                  - id: 7b09cdc3-8948-47f0-aa62-74ac943d6c59
-                    name: Engineering
-                  - id: 8c09cdc3-8948-47f0-aa62-74ac943d6c60
-                    name: Sales
-                  id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
-                  last_sign_in_at: '2018-02-02T22:25:27.521Z'
-                  organization_user_bypasses_sso: false
-                  record_type: organization_sub_user
-                  user_status: enabled
-                - created_at: '2018-01-01T00:00:00.000Z'
-                  email: owner@example.com
-                  groups: []
-                  id: 9d09cdc3-8948-47f0-aa62-74ac943d6c61
-                  last_sign_in_at: '2018-02-02T22:25:27.521Z'
-                  organization_user_bypasses_sso: false
-                  record_type: organization_owner
-                  user_status: enabled
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/OrganizationUserWithGroups'
-                    type: array
-                title: Users Groups Report Response
-                type: object
-            text/csv:
-              example: 'id,email,user_status,created_at,last_sign_in_at,groups
-
-                6a09cdc3-8948-47f0-aa62-74ac943d6c58,user@example.com,enabled,2018-02-02T22:25:27.521Z,2018-02-02T22:25:27.521Z,"Engineering,
-                Sales"'
-              schema:
-                description: 'CSV formatted report of users and their groups. Columns:
-                  id, email, user_status, created_at, last_sign_in_at, groups (comma-separated
-                  list of group names).'
-                type: string
-          description: Successful response with a list of organization users and their
-            group memberships.
+          $ref: '#/components/responses/UsersGroupsReportResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -92952,15 +94633,7 @@ paths:
       - $ref: '#/components/parameters/IncludeGroups'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OrganizationUser'
-                title: Organization User Response
-                type: object
-          description: Successful response with details about an Organization User.
+          $ref: '#/components/responses/OrganizationUserResponse'
         '400':
           $ref: '#/components/responses/users_BadRequestResponse'
         '401':
@@ -92988,15 +94661,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OrganizationUser'
-                title: Organization User Response
-                type: object
-          description: Successful response with details about an Organization User.
+          $ref: '#/components/responses/OrganizationUserResponse'
         '400':
           $ref: '#/components/responses/users_BadRequestResponse'
         '401':
@@ -93013,25 +94678,13 @@ paths:
       x-latency-category: interactive
   /ota_updates:
     get:
-      description: List OTA updates
       operationId: ListOtaUpdates
       parameters:
       - $ref: '#/components/parameters/FilterOTAUpdatesConsolidated'
       - $ref: '#/components/parameters/wireless_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SimplifiedOTAUpdate'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SearchOTAUpdateResponse'
         '401':
           description: Unauthorized
         default:
@@ -93048,14 +94701,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CompleteOTAUpdate'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/OTAUpdateResponse'
         '401':
           description: Unauthorized
         default:
@@ -93075,19 +94721,7 @@ paths:
       - $ref: '#/components/parameters/SortOutboundVoiceProfile'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/OutboundVoiceProfile'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Outbound Voice Profiles Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListOutboundVoiceProfilesResponse'
         '401':
           description: Unauthorized
         '422':
@@ -93111,15 +94745,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundVoiceProfile'
-                title: Outbound Voice Profile Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/OutboundVoiceProfileResponse'
         '401':
           description: Unauthorized
         '404':
@@ -93138,15 +94764,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundVoiceProfile'
-                title: Outbound Voice Profile Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/OutboundVoiceProfileResponse'
         '401':
           description: Unauthorized
         '404':
@@ -93164,15 +94782,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundVoiceProfile'
-                title: Outbound Voice Profile Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/OutboundVoiceProfileResponse'
         '401':
           description: Unauthorized
         '404':
@@ -93197,15 +94807,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/OutboundVoiceProfile'
-                title: Outbound Voice Profile Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/OutboundVoiceProfileResponse'
         '401':
           description: Unauthorized
         '404':
@@ -93222,14 +94824,7 @@ paths:
       operationId: GetAutoRechargePrefs
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/AutoRechargePref'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/AutoRechargePrefResponse'
         '400':
           description: Bad request
         '401':
@@ -93253,14 +94848,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/AutoRechargePref'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/AutoRechargePrefResponse'
         '401':
           description: Unauthorized
         '404':
@@ -93274,7 +94862,6 @@ paths:
       x-latency-category: responsive
   /phone_number_blocks/jobs:
     get:
-      description: Lists the phone number blocks jobs
       operationId: ListPhoneNumberBlocksJobs
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93314,20 +94901,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumberBlocksJob'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Phone Number Blocks Background Jobs Response
-                type: object
-          description: Successful response with a list of phone number blocks background
-            jobs.
+          $ref: '#/components/responses/ListPhoneNumberBlocksJobsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -93385,7 +94959,6 @@ paths:
       x-latency-category: background
   /phone_number_blocks/jobs/{id}:
     get:
-      description: Retrieves a phone number blocks job
       operationId: GetPhoneNumberBlocksJob
       parameters:
       - description: Identifies the Phone Number Blocks Job.
@@ -93422,7 +94995,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers:
     get:
-      description: List phone numbers
       operationId: ListPhoneNumbers
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93581,26 +95153,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumberDetailed'
-                    type: array
-                  errors:
-                    items:
-                      $ref: '#/components/schemas/numbers_Error'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                required:
-                - data
-                - meta
-                title: List Phone Numbers Response
-                type: object
-          description: Successful response with a list of phone numbers.
+          $ref: '#/components/responses/ListPhoneNumbersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -93656,25 +95209,12 @@ paths:
       x-latency-category: responsive
   /phone_numbers/csv_downloads:
     get:
-      description: List CSV downloads
       operationId: ListCsvDownloads
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CsvDownload'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List CSV Downloads Response
-                type: object
-          description: Successful response with a list of CSV downloads.
+          $ref: '#/components/responses/ListCsvDownloadsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -93692,7 +95232,6 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a CSV download
       operationId: CreateCsvDownload
       parameters:
       - description: Which format to use when generating the CSV file. The default
@@ -93795,17 +95334,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CsvDownload'
-                    type: array
-                title: CSV Download Response
-                type: object
-          description: Successful response with details about a CSV download.
+          $ref: '#/components/responses/CsvDownloadResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -93823,7 +95352,6 @@ paths:
       x-latency-category: background
   /phone_numbers/csv_downloads/{id}:
     get:
-      description: Retrieve a CSV download
       operationId: GetCsvDownload
       parameters:
       - description: Identifies the CSV download.
@@ -93834,17 +95362,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/CsvDownload'
-                    type: array
-                title: CSV Download Response
-                type: object
-          description: Successful response with details about a CSV download.
+          $ref: '#/components/responses/CsvDownloadResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -93862,7 +95380,6 @@ paths:
       x-latency-category: background
   /phone_numbers/jobs:
     get:
-      description: Lists the phone numbers jobs
       operationId: ListPhoneNumbersJobs
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93895,20 +95412,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumbersJob'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Phone Numbers Background Jobs Response
-                type: object
-          description: Successful response with a list of phone numbers background
-            jobs.
+          $ref: '#/components/responses/ListPhoneNumbersJobsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94256,7 +95760,6 @@ paths:
       x-latency-category: background
   /phone_numbers/jobs/{id}:
     get:
-      description: Retrieve a phone numbers job
       operationId: RetrievePhoneNumbersJob
       parameters:
       - description: Identifies the Phone Numbers Job.
@@ -94308,7 +95811,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers/messaging:
     get:
-      description: List phone numbers with messaging settings
       operationId: ListPhoneNumbersWithMessagingSettings
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -94352,20 +95854,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Messaging Settings Response
-                type: object
-          description: Successful response with a list of phone numbers with messaging
-            settings.
+          $ref: '#/components/responses/ListPhoneNumbersWithMessagingSettingsResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List phone numbers with messaging settings
@@ -94529,19 +96018,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SlimPhoneNumberDetailed'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Phone Numbers Response
-                type: object
-          description: Successful response with a list of phone numbers.
+          $ref: '#/components/responses/SlimListPhoneNumbersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94560,7 +96037,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers/voice:
     get:
-      description: List phone numbers with voice settings
       operationId: ListPhoneNumbersWithVoiceSettings
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -94614,20 +96090,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PhoneNumberWithVoiceSettings'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Phone Numbers With Voice Settings Response
-                type: object
-          description: Successful response with a list of phone numbers with voice
-            settings.
+          $ref: '#/components/responses/ListPhoneNumbersWithVoiceSettingsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94646,21 +96109,12 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}:
     delete:
-      description: Delete a phone number
       operationId: DeletePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberDeletedDetailed'
-                title: Phone Number Response
-                type: object
-          description: Successful response with details about a phone number.
+          $ref: '#/components/responses/DeletePhoneNumberResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94677,21 +96131,12 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
-      description: Retrieve a phone number
       operationId: RetrievePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberDetailed'
-                title: Phone Number Response
-                type: object
-          description: Successful response with details about a phone number.
+          $ref: '#/components/responses/PhoneNumberResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94708,7 +96153,6 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     patch:
-      description: Update a phone number
       operationId: UpdatePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94721,15 +96165,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberDetailed'
-                title: Phone Number Response
-                type: object
-          description: Successful response with details about a phone number.
+          $ref: '#/components/responses/PhoneNumberResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94747,8 +96183,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/actions/bundle_status_change:
     patch:
-      description: Change the bundle status for a phone number (set to being in a
-        bundle or remove from a bundle)
       operationId: PhoneNumberBundleStatusChange
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94787,7 +96221,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/actions/enable_emergency:
     post:
-      description: Enable emergency for a phone number
       operationId: EnablePhoneNumberEmergency
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94835,7 +96268,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/messaging:
     get:
-      description: Retrieve a phone number with messaging settings
       operationId: GetPhoneNumberMessagingSettings
       parameters:
       - description: Identifies the type of resource.
@@ -94846,16 +96278,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
-                title: Retrieve Messaging Settings Response
-                type: object
-          description: Successful response with details about a phone number including
-            messaging settings.
+          $ref: '#/components/responses/PhoneNumberWithMessagingSettingsResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve a phone number with messaging settings
@@ -94863,8 +96286,6 @@ paths:
       - Number Settings
       x-latency-category: responsive
     patch:
-      description: Update the messaging profile and/or messaging product of a phone
-        number
       operationId: UpdatePhoneNumberMessagingSettings
       parameters:
       - description: The phone number to update.
@@ -94885,16 +96306,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberWithMessagingSettings'
-                title: Retrieve Messaging Settings Response
-                type: object
-          description: Successful response with details about a phone number including
-            messaging settings.
+          $ref: '#/components/responses/PhoneNumberWithMessagingSettingsResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Update the messaging profile and/or messaging product of a phone number
@@ -94903,22 +96315,12 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/voice:
     get:
-      description: Retrieve a phone number with voice settings
       operationId: GetPhoneNumberVoiceSettings
       parameters:
       - $ref: '#/components/parameters/IntId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberWithVoiceSettings'
-                title: Retrieve Phone Number Voice Response
-                type: object
-          description: Successful response with details about a phone number including
-            voice settings.
+          $ref: '#/components/responses/PhoneNumberWithVoiceSettingsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94935,7 +96337,6 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     patch:
-      description: Update a phone number with voice settings
       operationId: UpdatePhoneNumberVoiceSettings
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94948,16 +96349,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PhoneNumberWithVoiceSettings'
-                title: Retrieve Phone Number Voice Response
-                type: object
-          description: Successful response with details about a phone number including
-            voice settings.
+          $ref: '#/components/responses/PhoneNumberWithVoiceSettingsResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -94979,14 +96371,7 @@ paths:
       operationId: GetVoicemail
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VoicemailPrefResponse'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VoicemailResponse'
         '400':
           description: Bad request
         '401':
@@ -95017,14 +96402,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VoicemailPrefResponse'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VoicemailResponse'
         '401':
           description: Unauthorized
         '404':
@@ -95047,14 +96425,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VoicemailPrefResponse'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VoicemailResponse'
         '401':
           description: Unauthorized
         '404':
@@ -95067,7 +96438,6 @@ paths:
       x-latency-category: responsive
   /phone_numbers_regulatory_requirements:
     get:
-      description: Retrieve regulatory requirements for a list of phone numbers
       operationId: ListRegulatoryRequirementsPhoneNumbers
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -95085,18 +96455,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RegulatoryRequirementsPhoneNumbers'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: An array of Regulatory Requirements Responses
+          $ref: '#/components/responses/listRegulatoryRequirementsPhoneNumbers'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -95134,16 +96493,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortabilityCheckDetails'
-                    type: array
-                type: object
-          description: PortabilityCheck Response
+          $ref: '#/components/responses/PortabilityCheckResponse'
         '401':
           description: Unauthorized
         '422':
@@ -95200,18 +96550,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingEvent'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingEventsResponse'
         '422':
           description: Unprocessable entity. Check the 'detail' field in response
             for details.
@@ -95235,14 +96574,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingEvent'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingEventResponse'
         '404':
           description: Not found
         '500':
@@ -95282,18 +96614,7 @@ paths:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingLOAConfiguration'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingLOAConfigurations'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95309,14 +96630,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingLOAConfiguration'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingLOAConfiguration'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreatePortingLOAConfiguration'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95334,13 +96648,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingLOAConfiguration'
       responses:
         '200':
-          content:
-            application/pdf:
-              schema:
-                example: '%PDF-1.4...'
-                format: binary
-                type: string
-          description: Successful response
+          $ref: '#/components/responses/DownloadLOATemplate'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95385,14 +96693,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingLOAConfiguration'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingLOAConfiguration'
         '404':
           description: Resource not found
         '500':
@@ -95416,14 +96717,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingLOAConfiguration'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingLOAConfiguration'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UpdatePortingLOAConfiguration'
         '404':
           description: Resource not found
         '422':
@@ -95448,13 +96742,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/pdf:
-              schema:
-                example: '%PDF-1.4...'
-                format: binary
-                type: string
-          description: Successful response
+          $ref: '#/components/responses/DownloadLOATemplate'
         '404':
           description: Resource not found
         '500':
@@ -95493,18 +96781,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingReport'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingReports'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95520,14 +96797,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingReport'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreatePortingReport'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95550,14 +96820,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingReport'
         '404':
           description: Resource not found
         '500':
@@ -95572,16 +96835,7 @@ paths:
       operationId: listPortingUKCarriers
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingUKCarrier'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingUKCarriersResponse'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -95692,18 +96946,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingOrder'
         '401':
           description: Unauthorized
         '422':
@@ -95723,86 +96966,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                  - activation_settings:
-                      activation_status: null
-                      fast_port_eligible: true
-                      foc_datetime_actual: null
-                      foc_datetime_requested: null
-                    created_at: '2022-03-17T18:01:01Z'
-                    customer_group_reference: null
-                    customer_reference: null
-                    description: FP Telnyx
-                    documents:
-                      invoice: null
-                      loa: null
-                    end_user:
-                      admin:
-                        account_number: null
-                        auth_person_name: null
-                        billing_phone_number: null
-                        business_identifier: null
-                        entity_name: null
-                        pin_passcode: null
-                        tax_identifier: null
-                      location:
-                        administrative_area: null
-                        country_code: null
-                        extended_address: null
-                        locality: null
-                        postal_code: null
-                        street_address: null
-                    id: b0ea6d6f-de31-4079-a536-992e0c98b037
-                    messaging:
-                      enable_messaging: false
-                      messaging_capable: true
-                      messaging_port_completed: false
-                      messaging_port_status: not_applicable
-                    misc: null
-                    old_service_provider_ocn: Unreal Communications
-                    parent_support_key: null
-                    phone_number_configuration:
-                      billing_group_id: null
-                      connection_id: null
-                      emergency_address_id: null
-                      messaging_profile_id: null
-                      tags: []
-                    phone_number_type: local
-                    phone_numbers:
-                    - activation_status: Activate RDY
-                      phone_number: '{e.164 TN}'
-                      phone_number_type: local
-                      portability_status: confirmed
-                      porting_order_id: b0ea6d6f-de31-4079-a536-992e0c98b037
-                      porting_order_status: draft
-                      record_type: porting_phone_number
-                      requirements_status: requirement-info-pending
-                      support_key: sr_10b316
-                    porting_phone_numbers_count: 1
-                    record_type: porting_order
-                    requirements: []
-                    requirements_met: false
-                    status:
-                      details: []
-                      value: draft
-                    support_key: null
-                    updated_at: '2022-03-17T18:01:01Z'
-                    user_feedback:
-                      user_comment: null
-                      user_rating: null
-                    user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
-                    webhook_url: null
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrder'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListDraftPortingOrdersWithoutPagination'
         '401':
           description: Unauthorized
         '422':
@@ -95818,16 +96982,7 @@ paths:
       parameters: []
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrdersExceptionType'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingOrdersExceptionTypes'
         '401':
           description: Unauthorized
         '422':
@@ -95904,18 +97059,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingPhoneNumberConfiguration'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingPhoneNumberConfigurations'
         '401':
           description: Unauthorized
         '422':
@@ -95931,16 +97075,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingPhoneNumberConfigurations'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingPhoneNumberConfiguration'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreatePortingPhoneNumberConfigurations'
         '401':
           description: Unauthorized
         '422':
@@ -95975,21 +97110,7 @@ paths:
       - $ref: '#/components/parameters/QueryIncludePhoneNumbers'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrder'
-                  meta:
-                    properties:
-                      phone_numbers_url:
-                        description: Link to list all phone numbers
-                        example: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
-                        type: string
-                    type: object
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingOrder'
         '401':
           description: Unauthorized
       summary: Retrieve a porting order
@@ -96019,85 +97140,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    activation_settings:
-                      activation_status: null
-                      fast_port_eligible: true
-                      foc_datetime_actual: null
-                      foc_datetime_requested: '2022-04-08T15:00:00Z'
-                    created_at: '2022-03-24T14:22:28Z'
-                    customer_group_reference: Group-789
-                    customer_reference: Test1234
-                    description: FP Telnyx
-                    documents:
-                      invoice: null
-                      loa: null
-                    end_user:
-                      admin:
-                        account_number: 123abc
-                        auth_person_name: Porter McPortersen II
-                        billing_phone_number: '+13035551234'
-                        business_identifier: abc123
-                        entity_name: Porter McPortersen
-                        pin_passcode: '1234'
-                        tax_identifier: 1234abcd
-                      location:
-                        administrative_area: TX
-                        country_code: US
-                        extended_address: 14th Floor
-                        locality: Austin
-                        postal_code: '78701'
-                        street_address: 600 Congress Avenue
-                    id: eef10fb8-f3df-4c67-97c5-e18179723222
-                    messaging:
-                      enable_messaging: true
-                      messaging_capable: true
-                      messaging_port_completed: false
-                      messaging_port_status: pending
-                    misc:
-                      new_billing_phone_number: null
-                      remaining_numbers_action: null
-                      type: full
-                    old_service_provider_ocn: Unreal Communications
-                    parent_support_key: null
-                    phone_number_configuration:
-                      billing_group_id: null
-                      connection_id: '1752379429071357070'
-                      emergency_address_id: null
-                      messaging_profile_id: null
-                      tags: []
-                    phone_number_type: local
-                    porting_phone_numbers_count: 1
-                    record_type: porting_order
-                    requirements: []
-                    requirements_met: false
-                    status:
-                      details: []
-                      value: draft
-                    support_key: null
-                    updated_at: '2022-03-24T14:26:53Z'
-                    user_feedback:
-                      user_comment: null
-                      user_rating: null
-                    user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
-                    webhook_url: https://example.com/porting_webhooks
-                  meta:
-                    phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrder'
-                  meta:
-                    properties:
-                      phone_numbers_url:
-                        description: Link to list all phone numbers
-                        type: string
-                    type: object
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UpdatePortingOrderResponse'
         '401':
           description: Unauthorized
         '422':
@@ -96115,14 +97158,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrderID'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrdersActivationJob'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingOrdersActivationJob'
         '401':
           description: Unauthorized
         '422':
@@ -96139,80 +97175,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrderID'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    activation_settings:
-                      activation_status: null
-                      fast_port_eligible: true
-                      foc_datetime_actual: null
-                      foc_datetime_requested: '2022-04-08T15:00:00Z'
-                    created_at: '2022-03-24T14:22:28Z'
-                    customer_group_reference: Group-789
-                    customer_reference: Test1234
-                    description: FP Telnyx
-                    documents:
-                      invoice: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
-                      loa: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
-                    end_user:
-                      admin:
-                        account_number: 123abc
-                        auth_person_name: Porter McPortersen II
-                        billing_phone_number: '+13035551234'
-                        business_identifier: abc123
-                        entity_name: Porter McPortersen
-                        pin_passcode: '1234'
-                        tax_identifier: 1234abcd
-                      location:
-                        administrative_area: TX
-                        country_code: US
-                        extended_address: 14th Floor
-                        locality: Austin
-                        postal_code: '78701'
-                        street_address: 600 Congress Avenue
-                    id: eef10fb8-f3df-4c67-97c5-e18179723222
-                    misc:
-                      new_billing_phone_number: null
-                      remaining_numbers_action: null
-                      type: full
-                    old_service_provider_ocn: Unreal Communications
-                    parent_support_key: pr_4bec1a
-                    phone_number_configuration:
-                      billing_group_id: null
-                      connection_id: '1752379429071357070'
-                      emergency_address_id: null
-                      messaging_profile_id: null
-                      tags: []
-                    phone_number_type: local
-                    porting_phone_numbers_count: 1
-                    record_type: porting_order
-                    requirements: []
-                    requirements_met: true
-                    status:
-                      details: []
-                      value: cancel-pending
-                    support_key: sr_10b316
-                    updated_at: '2022-03-24T16:43:35Z'
-                    user_feedback:
-                      user_comment: null
-                      user_rating: null
-                    user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
-                    webhook_url: https://example.com/porting_webhooks
-                  meta:
-                    phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrder'
-                  meta:
-                    properties:
-                      phone_numbers_url:
-                        description: Link to list all phone numbers
-                        type: string
-                    type: object
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CancelPortingOrderResponse'
         '401':
           description: Unauthorized
         '422':
@@ -96229,85 +97192,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrderID'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    activation_settings:
-                      activation_status: null
-                      fast_port_eligible: true
-                      foc_datetime_actual: null
-                      foc_datetime_requested: '2022-04-08T15:00:00Z'
-                    created_at: '2022-03-24T14:22:28Z'
-                    customer_group_reference: Group-789
-                    customer_reference: Test1234
-                    description: FP Telnyx
-                    documents:
-                      invoice: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
-                      loa: 3a5b98a0-5049-47c3-96e1-aa6c8d119117
-                    end_user:
-                      admin:
-                        account_number: 123abc
-                        auth_person_name: Porter McPortersen II
-                        billing_phone_number: '+13035551234'
-                        business_identifier: abc123
-                        entity_name: Porter McPortersen
-                        pin_passcode: '1234'
-                        tax_identifier: 1234abcd
-                      location:
-                        administrative_area: TX
-                        country_code: US
-                        extended_address: 14th Floor
-                        locality: Austin
-                        postal_code: '78701'
-                        street_address: 600 Congress Avenue
-                    id: eef10fb8-f3df-4c67-97c5-e18179723222
-                    messaging:
-                      enable_messaging: false
-                      messaging_capable: true
-                      messaging_port_completed: false
-                      messaging_port_status: not_applicable
-                    misc:
-                      new_billing_phone_number: null
-                      remaining_numbers_action: null
-                      type: full
-                    old_service_provider_ocn: Unreal Communications
-                    parent_support_key: pr_4bec1a
-                    phone_number_configuration:
-                      billing_group_id: null
-                      connection_id: '1752379429071357070'
-                      emergency_address_id: null
-                      messaging_profile_id: null
-                      tags: []
-                    phone_number_type: local
-                    porting_phone_numbers_count: 1
-                    record_type: porting_order
-                    requirements: []
-                    requirements_met: true
-                    status:
-                      details: []
-                      value: in-process
-                    support_key: sr_10b316
-                    updated_at: '2022-03-24T16:42:43Z'
-                    user_feedback:
-                      user_comment: null
-                      user_rating: null
-                    user_id: 40d68ba2-0847-4df2-be9c-b0e0cb673e75
-                    webhook_url: https://example.com/porting_webhooks
-                  meta:
-                    phone_numbers_url: /v2/porting_phone_numbers?filter[porting_order_id]=eef10fb8-f3df-4c67-97c5-e18179723222
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrder'
-                  meta:
-                    properties:
-                      phone_numbers_url:
-                        description: Link to list all phone numbers
-                        type: string
-                    type: object
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ConfirmPortingOrderResponse'
         '401':
           description: Unauthorized
         '422':
@@ -96327,26 +97212,7 @@ paths:
         $ref: '#/components/requestBodies/SharePortingOrder'
       responses:
         '201':
-          content:
-            application/json:
-              example:
-                data:
-                  created_at: '2023-07-20T22:11:17.292573Z'
-                  expires_at: '2023-07-20T23:11:17Z'
-                  expires_in_seconds: 3600
-                  id: 03a35311-ad92-46b3-95d7-8ad6dccf2d7c
-                  permissions:
-                  - porting_order.document.read
-                  - porting_order.document.update
-                  porting_order_id: fd4b86c8-497d-4c6d-9609-a789e4e14cfe
-                  record_type: porting_order_sharing_token
-                  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODk4OTQ2NzcsImlzdCI6MTY4OTg5MTA3NywicGVybWlzc2lvbnMiOlsicG9ydGluZ19vcmRlci5kb2N1bWVudC5yZWFkIl0sInBvcnRpbmdfb3JkZXJfaWQiOiJmZDRiODZjOC00OTdkLTRjNmQtOTYwOS1hNzg5ZTRlMTRjZmUifQ.CT0HRF6OLj7VPZ8p5Y_0S8rOL8SEUznwJJkR-YReKwc
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrderSharingToken'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SharePortingOrder'
         '401':
           description: Unauthorized
         '404':
@@ -96364,18 +97230,7 @@ paths:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrdersActivationJob'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingOrdersActivationJobs'
         '401':
           description: Unauthorized
         '422':
@@ -96393,14 +97248,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrdersActivationJobID'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrdersActivationJob'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingOrdersActivationJob'
         '401':
           description: Unauthorized
         '422':
@@ -96419,14 +97267,7 @@ paths:
         $ref: '#/components/requestBodies/UpdatePortingOrdersActivationJob'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrdersActivationJob'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingOrdersActivationJob'
         '404':
           description: Not found
         '422':
@@ -96481,32 +97322,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                  - created_at: '2023-06-01T10:00:00.00000Z'
-                    document_id: 40bc547a-7f96-4cd5-926a-da4842671e88
-                    document_type: loa
-                    id: 2acd1061-33cb-49b8-8014-beb6dc3fedbf
-                    porting_order_id: 9d7b3b8e-4e67-4837-9c44-d110cd2c82a1
-                    record_type: porting_additional_document
-                    updated_at: '2023-06-01T10:00:00.00000Z'
-                  meta:
-                    page_number: 1
-                    page_size: 25
-                    total_pages: 1
-                    total_results: 1
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingAdditionalDocument'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingAdditionalDocuments'
         '401':
           description: Unauthorized
         '404':
@@ -96524,25 +97340,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingAdditionalDocuments'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                  - created_at: '2023-06-01T10:00:00.00000Z'
-                    document_id: 40bc547a-7f96-4cd5-926a-da4842671e88
-                    document_type: loa
-                    id: 2acd1061-33cb-49b8-8014-beb6dc3fedbf
-                    porting_order_id: 9d7b3b8e-4e67-4837-9c44-d110cd2c82a1
-                    record_type: porting_additional_document
-                    updated_at: '2023-06-01T10:00:00.00000Z'
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingAdditionalDocument'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreatePortingAdditionalDocuments'
         '401':
           description: Unauthorized
         '404':
@@ -96585,18 +97383,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrderID'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrdersAllowedFocWindow'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListAllowedFocWindows'
         '401':
           description: Unauthorized
       summary: List allowed FOC dates
@@ -96612,18 +97399,7 @@ paths:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrdersComment'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingOrdersComments'
         '401':
           description: Unauthorized
         '422':
@@ -96645,14 +97421,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingOrdersComment'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingOrdersComment'
         '401':
           description: Unauthorized
         '422':
@@ -96678,13 +97447,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/pdf:
-              schema:
-                example: '%PDF-1.4...'
-                format: binary
-                type: string
-          description: Successful response
+          $ref: '#/components/responses/DownloadLOATemplate'
         '401':
           description: Unauthorized
       summary: Download a porting order loa template
@@ -96701,18 +97464,7 @@ paths:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingOrderRequirementDetail'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingOrderRequirements'
         '401':
           description: Unauthorized
         '422':
@@ -96729,14 +97481,7 @@ paths:
       - $ref: '#/components/parameters/PathPortingOrderID'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/GetSubRequestByPortingOrder'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SubRequestByPortingOrder'
         '401':
           description: Unauthorized
         '404':
@@ -96784,37 +97529,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                  - created_at: '2020-10-22T15:00:00.000Z'
-                    id: 52090326-6533-4421-bcf4-bd0117cf3954
-                    phone_number: '+61424000001'
-                    porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
-                    updated_at: '2020-10-22T15:00:00.000Z'
-                    verified: true
-                  - created_at: '2020-10-22T15:00:00.000Z'
-                    id: cf076b8e-645b-4040-8209-543c5909775f
-                    phone_number: '+61424000002'
-                    porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
-                    updated_at: '2020-10-22T15:00:00.000Z'
-                    verified: false
-                  meta:
-                    page_number: 1
-                    page_size: 2
-                    total_pages: 1
-                    total_results: 2
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingVerificationCode'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingVerificationCodes'
         '401':
           description: Unauthorized
         '404':
@@ -96854,30 +97569,7 @@ paths:
         $ref: '#/components/requestBodies/VerifyPortingVerificationCodes'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                  - created_at: '2020-10-22T15:00:00.000Z'
-                    id: 52090326-6533-4421-bcf4-bd0117cf3954
-                    phone_number: '+61424000001'
-                    porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
-                    updated_at: '2020-10-22T15:00:00.000Z'
-                    verified: true
-                  - created_at: '2020-10-22T15:00:00.000Z'
-                    id: cf076b8e-645b-4040-8209-543c5909775f
-                    phone_number: '+61424000002'
-                    porting_order_id: f28e6ecc-29a8-430b-bd0b-d93055f70604
-                    updated_at: '2020-10-22T15:00:00.000Z'
-                    verified: false
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingVerificationCode'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VerifyPortingVerificationCodes'
         '401':
           description: Unauthorized
         '404':
@@ -96954,18 +97646,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingActionRequirement'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingActionRequirements'
         '401':
           description: Unauthorized
         '404':
@@ -96997,14 +97678,7 @@ paths:
         $ref: '#/components/requestBodies/InitiatePortingActionRequirement'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingActionRequirement'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingActionRequirement'
         '400':
           description: Bad request
         '401':
@@ -97075,18 +97749,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingAssociatedPhoneNumber'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingAssociatedPhoneNumbers'
         '401':
           description: Unauthorized
         '404':
@@ -97114,14 +97777,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingAssociatedPhoneNumber'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingAssociatedPhoneNumber'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingAssociatedPhoneNumber'
         '404':
           description: Not found
         '422':
@@ -97151,14 +97807,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingAssociatedPhoneNumber'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingAssociatedPhoneNumber'
         '404':
           description: Not found
         '422':
@@ -97201,18 +97850,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingPhoneNumberBlock'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingPhoneNumberBlocks'
         '401':
           description: Unauthorized
         '404':
@@ -97239,14 +97877,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingPhoneNumberBlock'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingPhoneNumberBlock'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingPhoneNumberBlock'
         '404':
           description: Not found
         '422':
@@ -97277,14 +97908,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingPhoneNumberBlock'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingPhoneNumberBlock'
         '404':
           description: Not found
         '422':
@@ -97340,18 +97964,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingPhoneNumberExtension'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortingPhoneNumberExtensions'
         '401':
           description: Unauthorized
         '404':
@@ -97378,14 +97991,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortingPhoneNumberExtension'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingPhoneNumberExtension'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingPhoneNumberExtension'
         '404':
           description: Not found
         '422':
@@ -97416,14 +98022,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortingPhoneNumberExtension'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortingPhoneNumberExtension'
         '404':
           description: Not found
         '422':
@@ -97462,24 +98061,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortingPhoneNumber'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-            text/csv:
-              schema:
-                example: "phone_number,phone_number_type,porting_order_id,support_key,porting_order_status\r\
-                  \n+12003155566,local,5f940c35-ef28-4408-bb95-af73b047d589,sr_a12345,draft\r\
-                  \n"
-                type: string
-          description: Successful response
+          $ref: '#/components/responses/ListPortingPhoneNumbers'
         '401':
           description: Unauthorized
         '422':
@@ -97593,18 +98175,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortoutDetails'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/Metadata'
-                type: object
-          description: Portout Response
+          $ref: '#/components/responses/ListPortoutResponse'
         '401':
           description: Unauthorized
         '404':
@@ -97659,18 +98230,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortoutEvent'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortoutEventsResponse'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -97693,14 +98253,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutEvent'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortoutEventResponse'
         '404':
           description: Not found
         '500':
@@ -97768,16 +98321,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortoutRejection'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortoutRejections'
         '404':
           description: Resource not found
         '422':
@@ -97818,18 +98362,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortoutReport'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListPortoutReports'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -97845,14 +98378,7 @@ paths:
         $ref: '#/components/requestBodies/CreatePortoutReport'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreatePortoutReport'
         '422':
           description: Unprocessable entity. Check message field in response for details.
         '500':
@@ -97875,14 +98401,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ShowPortoutReport'
         '404':
           description: Resource not found
         '500':
@@ -97905,14 +98424,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutDetails'
-                type: object
-          description: Portout Response
+          $ref: '#/components/responses/PortoutResponse'
         '401':
           description: Unauthorized
         '404':
@@ -97937,18 +98449,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortoutComment'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/Metadata'
-                type: object
-          description: Portout Comments
+          $ref: '#/components/responses/ListPortoutComments'
         '401':
           description: Unauthorized
         '404':
@@ -97982,14 +98483,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutComment'
-                type: object
-          description: Portout Comment Response
+          $ref: '#/components/responses/PortoutCommentResponse'
         '401':
           description: Unauthorized
         '404':
@@ -98014,16 +98508,7 @@ paths:
           type: string
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortOutSupportingDocument'
-                    type: array
-                type: object
-          description: Portout Supporting Documents
+          $ref: '#/components/responses/PortOutListSupportingDocumentsResponse'
         '401':
           description: Unauthorized
         '404':
@@ -98075,16 +98560,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PortOutSupportingDocument'
-                    type: array
-                type: object
-          description: Portout Supporting Documents
+          $ref: '#/components/responses/CreatePortOutSupportingDocumentsResponse'
         '401':
           description: Unauthorized
         '404':
@@ -98137,14 +98613,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PortoutDetails'
-                type: object
-          description: Portout Response
+          $ref: '#/components/responses/PortoutResponse'
         '401':
           description: Unauthorized
         '404':
@@ -98200,18 +98669,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PrivateWirelessGateway'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetAllPrivateWirelessGatewaysResponse'
         '401':
           description: Unauthorized
         default:
@@ -98253,31 +98711,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    assigned_resources:
-                    - count: 1
-                      record_type: sim_card_group
-                    created_at: '2018-02-02T22:25:27.521Z'
-                    id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
-                    ip_range: 100.64.1.0/24
-                    name: My private wireless gateway
-                    network_id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
-                    record_type: private_wireless_gateway
-                    region_code: dc2
-                    status:
-                      error_code: null
-                      error_description: null
-                      value: provisioning
-                    updated_at: '2018-02-02T22:25:27.521Z'
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PrivateWirelessGateway'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreatePrivateWirelessGatewayResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -98294,14 +98728,7 @@ paths:
       - $ref: '#/components/parameters/PrivateWirelessGatewayId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PrivateWirelessGateway'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/DeletePrivateWirelessGatewayResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -98317,14 +98744,7 @@ paths:
       - $ref: '#/components/parameters/PrivateWirelessGatewayId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PrivateWirelessGateway'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetPrivateWirelessGatewayResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -98594,18 +99014,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/PublicInternetGatewayRead'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/PublicInternetGatewayListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -98625,14 +99034,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PublicInternetGatewayRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/PublicInternetGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -98649,14 +99051,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PublicInternetGatewayRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/PublicInternetGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -98672,14 +99067,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/PublicInternetGatewayRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/PublicInternetGatewayResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -98712,19 +99100,7 @@ paths:
           type: integer
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Queue'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Queues Response
-                type: object
-          description: Successful response with a list of queues.
+          $ref: '#/components/responses/ListQueuesResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -98743,15 +99119,7 @@ paths:
               $ref: '#/components/schemas/CreateQueueRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Queue'
-                title: Queue Response
-                type: object
-          description: Successful response with details about a queue.
+          $ref: '#/components/responses/QueueResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '422':
@@ -98794,15 +99162,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Queue'
-                title: Queue Response
-                type: object
-          description: Successful response with details about a queue.
+          $ref: '#/components/responses/QueueResponse'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
       summary: Retrieve a call queue
@@ -98826,15 +99186,7 @@ paths:
               $ref: '#/components/schemas/UpdateQueueRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Queue'
-                title: Queue Response
-                type: object
-          description: Successful response with details about a queue.
+          $ref: '#/components/responses/QueueResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedResponse'
         '404':
@@ -98859,19 +99211,7 @@ paths:
       - $ref: '#/components/parameters/call-control_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/QueueCall'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Queue Calls Response
-                type: object
-          description: Successful response with a list of calls in a queue.
+          $ref: '#/components/responses/ListQueueCallsResponse'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
       summary: Retrieve calls from a queue
@@ -98913,15 +99253,7 @@ paths:
       - $ref: '#/components/parameters/CallControlId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/QueueCall'
-                title: Queue Call Response
-                type: object
-          description: Successful response with details about a call in a queue.
+          $ref: '#/components/responses/QueueCallResponse'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
       summary: Retrieve a call from a queue
@@ -98991,18 +99323,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RecordingTranscription'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/call-recordings_CursorPaginationMeta'
-                type: object
-          description: A response listing multiple recording transcriptions.
+          $ref: '#/components/responses/ListRecordingTranscriptionsResponse'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -99021,14 +99342,7 @@ paths:
       - $ref: '#/components/parameters/RecordingTranscriptionId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RecordingTranscription'
-                type: object
-          description: A response with a single recording transcription resource.
+          $ref: '#/components/responses/RecordingTranscriptionResponse'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -99046,14 +99360,7 @@ paths:
       - $ref: '#/components/parameters/RecordingTranscriptionId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RecordingTranscription'
-                type: object
-          description: A response with a single recording transcription resource.
+          $ref: '#/components/responses/RecordingTranscriptionResponse'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -99168,18 +99475,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RecordingResponseData'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: A response containing multiple recordings.
+          $ref: '#/components/responses/RecordingsResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '403':
@@ -99231,11 +99527,7 @@ paths:
       - $ref: '#/components/parameters/RecordingId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordingResponse'
-          description: A response with a single recording resource.
+          $ref: '#/components/responses/RecordingResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -99253,11 +99545,7 @@ paths:
       - $ref: '#/components/parameters/RecordingId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordingResponse'
-          description: A response with a single recording resource.
+          $ref: '#/components/responses/RecordingResponseBody'
         '401':
           $ref: '#/components/responses/call-recordings_UnauthorizedResponse'
         '404':
@@ -99274,16 +99562,7 @@ paths:
       operationId: ListRegions
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/netapps_Region'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/RegionListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -99294,7 +99573,6 @@ paths:
       x-latency-category: responsive
   /regulatory_requirements:
     get:
-      description: Retrieve regulatory requirements
       operationId: ListRegulatoryRequirements
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -99337,16 +99615,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RegulatoryRequirements'
-                    type: array
-                type: object
-          description: An array of Regulatory Requirements Responses
+          $ref: '#/components/responses/listRegulatoryRequirements'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -99963,7 +100232,6 @@ paths:
       x-latency-category: responsive
   /requirement_groups:
     get:
-      description: List requirement groups
       operationId: GetRequirementGroups
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100029,7 +100297,6 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     post:
-      description: Create a new requirement group
       operationId: CreateRequirementGroup
       requestBody:
         content:
@@ -100094,7 +100361,6 @@ paths:
       x-latency-category: responsive
   /requirement_groups/{id}:
     delete:
-      description: Delete a requirement group by ID
       operationId: DeleteRequirementGroup
       parameters:
       - description: ID of the requirement group
@@ -100125,7 +100391,6 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     get:
-      description: Get a single requirement group by ID
       operationId: GetRequirementGroup
       parameters:
       - description: ID of the requirement group to retrieve
@@ -100156,7 +100421,6 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     patch:
-      description: Update requirement values in requirement group
       operationId: UpdateRequirementGroup
       parameters:
       - description: ID of the requirement group
@@ -100212,7 +100476,6 @@ paths:
       x-latency-category: responsive
   /requirement_groups/{id}/submit_for_approval:
     post:
-      description: Submit a Requirement Group for Approval
       operationId: SubmitRequirementGroup
       parameters:
       - description: ID of the requirement group to submit
@@ -100251,16 +100514,7 @@ paths:
       - $ref: '#/components/parameters/SortRequirementTypesConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocReqsRequirementTypeList'
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocReqsListRequirementTypesResponse'
         '422':
           content:
             application/json:
@@ -100282,14 +100536,7 @@ paths:
       - $ref: '#/components/parameters/DocReqsRequirementTypeId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocReqsRequirementType'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocReqsRequirementTypeResponse'
         '422':
           content:
             application/json:
@@ -100313,16 +100560,7 @@ paths:
       - $ref: '#/components/parameters/documents_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocReqsRequirementList'
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/ListRequirementsResponse'
         '422':
           content:
             application/json:
@@ -100344,14 +100582,7 @@ paths:
       - $ref: '#/components/parameters/DocReqsRequirementId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/DocReqsRequirement'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DocReqsRequirementResponse'
         '422':
           content:
             application/json:
@@ -100367,7 +100598,7 @@ paths:
       x-latency-category: responsive
   /room_compositions:
     get:
-      description: View a list of room compositions.
+      description: ''
       operationId: ListRoomCompositions
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100418,18 +100649,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomComposition'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room compositions response.
+          $ref: '#/components/responses/ListRoomCompositionsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room compositions.
@@ -100449,14 +100669,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RoomComposition'
-                type: object
-          description: Create room composition response.
+          $ref: '#/components/responses/CreateRoomCompositionResponse'
         '422':
           $ref: '#/components/responses/video_UnprocessableEntity'
       summary: Create a room composition.
@@ -100488,7 +100701,6 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
-      description: View a room composition.
       operationId: ViewRoomComposition
       parameters:
       - description: The unique identifier of a room composition.
@@ -100501,14 +100713,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RoomComposition'
-                type: object
-          description: Get room composition response.
+          $ref: '#/components/responses/GetRoomCompositionResponse'
         '404':
           $ref: '#/components/responses/video_ResourceNotFound'
       summary: View a room composition.
@@ -100518,7 +100723,7 @@ paths:
       x-latency-category: responsive
   /room_participants:
     get:
-      description: View a list of room participants.
+      description: ''
       operationId: ListRoomParticipants
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100608,18 +100813,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomParticipant'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room participants response.
+          $ref: '#/components/responses/ListRoomParticipantsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room participants.
@@ -100629,7 +100823,6 @@ paths:
       x-latency-category: responsive
   /room_participants/{room_participant_id}:
     get:
-      description: View a room participant.
       operationId: ViewRoomParticipant
       parameters:
       - description: The unique identifier of a room participant.
@@ -100642,14 +100835,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RoomParticipant'
-                type: object
-          description: Get room participant response.
+          $ref: '#/components/responses/GetRoomParticipantResponse'
         '404':
           $ref: '#/components/responses/video_ResourceNotFound'
       summary: View a room participant.
@@ -100659,7 +100845,7 @@ paths:
       x-latency-category: responsive
   /room_recordings:
     delete:
-      description: Delete several room recordings in a bulk.
+      description: ''
       operationId: DeleteRoomRecordings
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100747,20 +100933,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      room_recordings:
-                        description: Amount of room recordings affected
-                        example: 5
-                        type: integer
-                    type: object
-                title: Bulk Room Recordings Delete Response
-                type: object
-          description: Successful response for Bulk Delete Room recordings requests
+          $ref: '#/components/responses/BulkDeleteRoomRecordingsResponse'
         '422':
           $ref: '#/components/responses/video_UnprocessableEntity'
       summary: Delete several room recordings in a bulk.
@@ -100769,7 +100942,7 @@ paths:
       x-endpoint-cost: heavy
       x-latency-category: responsive
     get:
-      description: View a list of room recordings.
+      description: ''
       operationId: ListRoomRecordings
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100857,18 +101030,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomRecording'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room recordings response.
+          $ref: '#/components/responses/ListRoomRecordingsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room recordings.
@@ -100900,7 +101062,6 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
-      description: View a room recording.
       operationId: ViewRoomRecording
       parameters:
       - description: The unique identifier of a room recording.
@@ -100913,14 +101074,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RoomRecording'
-                type: object
-          description: Get room recording response.
+          $ref: '#/components/responses/GetRoomRecordingResponse'
         '404':
           $ref: '#/components/responses/video_ResourceNotFound'
       summary: View a room recording.
@@ -100930,7 +101084,7 @@ paths:
       x-latency-category: responsive
   /room_sessions:
     get:
-      description: View a list of room sessions.
+      description: ''
       operationId: ListRoomSessions
       parameters:
       - description: To decide if room participants should be included in the response.
@@ -101026,18 +101180,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomSession'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room sessions response.
+          $ref: '#/components/responses/ListRoomSessionsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room sessions.
@@ -101047,7 +101190,6 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}:
     get:
-      description: View a room session.
       operationId: ViewRoomSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101066,14 +101208,7 @@ paths:
           type: boolean
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/RoomSession'
-                type: object
-          description: Get room session response.
+          $ref: '#/components/responses/GetRoomSessionResponse'
         '404':
           $ref: '#/components/responses/video_ResourceNotFound'
       summary: View a room session.
@@ -101097,18 +101232,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                type: object
-          description: Success Action Response
+          $ref: '#/components/responses/ActionSuccessResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       security: []
@@ -101119,7 +101243,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/kick:
     post:
-      description: Kick participants from a room session.
+      description: ''
       operationId: KickParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101139,18 +101263,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                type: object
-          description: Success Action Response
+          $ref: '#/components/responses/ActionSuccessResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       security: []
@@ -101161,7 +101274,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/mute:
     post:
-      description: Mute participants in room session.
+      description: ''
       operationId: MuteParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101181,18 +101294,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                type: object
-          description: Success Action Response
+          $ref: '#/components/responses/ActionSuccessResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       security: []
@@ -101203,7 +101305,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/unmute:
     post:
-      description: Unmute participants in room session.
+      description: ''
       operationId: UnmuteParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101223,18 +101325,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      result:
-                        example: ok
-                        type: string
-                    type: object
-                type: object
-          description: Success Action Response
+          $ref: '#/components/responses/ActionSuccessResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       security: []
@@ -101245,7 +101336,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/participants:
     get:
-      description: View a list of room participants.
+      description: ''
       operationId: RetrieveListRoomParticipants
       parameters:
       - description: The unique identifier of a room session.
@@ -101339,18 +101430,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomParticipant'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room participants response.
+          $ref: '#/components/responses/ListRoomParticipantsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room participants.
@@ -101360,7 +101440,7 @@ paths:
       x-latency-category: responsive
   /rooms:
     get:
-      description: View a list of rooms.
+      description: ''
       operationId: ListRooms
       parameters:
       - description: To decide if room sessions should be included in the response.
@@ -101428,18 +101508,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/Room'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List rooms response.
+          $ref: '#/components/responses/ListRoomsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of rooms.
@@ -101459,14 +101528,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Room'
-                type: object
-          description: Create room response.
+          $ref: '#/components/responses/CreateRoomResponse'
         '422':
           $ref: '#/components/responses/video_UnprocessableEntity'
       summary: Create a room.
@@ -101500,7 +101562,6 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
-      description: View a room.
       operationId: ViewRoom
       parameters:
       - description: The unique identifier of a room.
@@ -101519,14 +101580,7 @@ paths:
           type: boolean
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Room'
-                type: object
-          description: Get room response.
+          $ref: '#/components/responses/GetRoomResponse'
         '404':
           $ref: '#/components/responses/video_ResourceNotFound'
       summary: View a room.
@@ -101555,14 +101609,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Room'
-                type: object
-          description: Update room response.
+          $ref: '#/components/responses/PatchRoomResponse'
         '401':
           $ref: '#/components/responses/video_UnauthorizedResponse'
         '404':
@@ -101599,36 +101646,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    example:
-                      refresh_token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDkzNzA1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6ImQ3OWJlMzhjLWFkNTQtNGQ5ZC1hODc4LWExNjVjNTk0MGQwNyIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6InJlZnJlc2gifQ.FHsp7KlVXn1E5tTUiKZzmQ4of39gi57AakeQeqI0oAa8hzjFMVb0RGj-mxWTvHVen4GpgsUW_epqqaxK16viCA
-                      refresh_token_expires_at: '2021-04-22T12:15:05Z'
-                      token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDk0Mjk1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6IjllNjIyOTA2LTc1ZTctNDBiNi1iOTAwLTc1NGIxZjNlZDMyZiIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6ImFjY2VzcyJ9.1JGK9PyHkTtoP_iMu-8TzXH_fhmnsDtZZOAJLDzLW6DDtAb80wZ93l1VH5yNx5tFqwIFG0t48dRiBKWlW-nzDA
-                      token_expires_at: '2021-04-22T12:24:55Z'
-                    properties:
-                      refresh_token:
-                        example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
-                        type: string
-                      refresh_token_expires_at:
-                        description: ISO 8601 timestamp when the refresh token expires.
-                        example: '2021-03-26T17:51:59Z'
-                        format: date-time
-                        type: string
-                      token:
-                        example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
-                        type: string
-                      token_expires_at:
-                        description: ISO 8601 timestamp when the token expires.
-                        example: '2021-03-26T17:51:59Z'
-                        format: date-time
-                        type: string
-                    type: object
-                type: object
-          description: Create room client token response.
+          $ref: '#/components/responses/CreateRoomClientTokenResponse'
         '403':
           $ref: '#/components/responses/Forbidden'
       summary: Create Client Token to join a room.
@@ -101659,26 +101677,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    example:
-                      token: eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJ0ZWxueXhfYWNjZXNzX3Rva2VuIiwiZXhwIjoxNjE5MDk0Mjk1LCJncmFudHMiOlt7ImFjdGlvbnMiOlsiam9pbiJdLCJyZXNvdXJjZXMiOlsidGVsbnl4OnZpZGVvOnJvb21zOjllMmEwY2JlLWNlNjYtNDExZS1hMWFjLTQ2OGYwYjEwM2M5YSJdLCJzdWJqZWN0cyI6WyJ0ZWxueXg6dXNlcnM6NzgyYjJjYmUtODQ2Ni00ZTNmLWE0ZDMtOTc4MWViNTc3ZTUwIl19XSwiZ3JhbnRzX3ZlcnNpb24iOiIxLjAuMCIsImlhdCI6MTYxOTA5MzY5NSwiaXNzIjoidGVsbnl4X2FjY2Vzc190b2tlbiIsImp0aSI6IjllNjIyOTA2LTc1ZTctNDBiNi1iOTAwLTc1NGIxZjNlZDMyZiIsIm5iZiI6MTYxOTA5MzY5NCwic3ViIjoibnVsbCIsInR5cCI6ImFjY2VzcyJ9.1JGK9PyHkTtoP_iMu-8TzXH_fhmnsDtZZOAJLDzLW6DDtAb80wZ93l1VH5yNx5tFqwIFG0t48dRiBKWlW-nzDA
-                      token_expires_at: '2021-04-22T12:24:55Z'
-                    properties:
-                      token:
-                        example: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZWxueXhfdGVsZXBob255IiwiZXhwIjoxNTkwMDEwMTQzLCJpYXQiOjE1ODc1OTA5NDMsImlzcyI6InRlbG55eF90ZWxlcGhvbnkiLCJqdGkiOiJiOGM3NDgzNy1kODllLTRhNjUtOWNmMi0zNGM3YTZmYTYwYzgiLCJuYmYiOjE1ODc1OTA5NDIsInN1YiI6IjVjN2FjN2QwLWRiNjUtNGYxMS05OGUxLWVlYzBkMWQ1YzZhZSIsInRlbF90b2tlbiI6InJqX1pra1pVT1pNeFpPZk9tTHBFVUIzc2lVN3U2UmpaRmVNOXMtZ2JfeENSNTZXRktGQUppTXlGMlQ2Q0JSbWxoX1N5MGlfbGZ5VDlBSThzRWlmOE1USUlzenl6U2xfYURuRzQ4YU81MHlhSEd1UlNZYlViU1ltOVdJaVEwZz09IiwidHlwIjoiYWNjZXNzIn0.gNEwzTow5MLLPLQENytca7pUN79PmPj6FyqZWW06ZeEmesxYpwKh0xRtA0TzLh6CDYIRHrI8seofOO0YFGDhpQ
-                        type: string
-                      token_expires_at:
-                        description: ISO 8601 timestamp when the token expires.
-                        example: '2021-03-26T17:51:59Z'
-                        format: date-time
-                        type: string
-                    type: object
-                type: object
-          description: Refresh room client token response.
+          $ref: '#/components/responses/RefreshRoomClientTokenResponse'
         '403':
           $ref: '#/components/responses/Forbidden'
       security: []
@@ -101689,7 +101688,7 @@ paths:
       x-latency-category: responsive
   /rooms/{room_id}/sessions:
     get:
-      description: View a list of room sessions.
+      description: ''
       operationId: RetrieveListRoomSessions
       parameters:
       - description: The unique identifier of a room.
@@ -101789,18 +101788,7 @@ paths:
       - $ref: '#/components/parameters/video_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/RoomSession'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: List room sessions response.
+          $ref: '#/components/responses/ListRoomSessionsResponse'
         4XX:
           $ref: '#/components/responses/video_GenericErrorResponse'
       summary: View a list of room sessions.
@@ -102005,16 +101993,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/BlackBoxTestResultSet'
-                    type: array
-                type: object
-          description: A list of black box test results.
+          $ref: '#/components/responses/BlackBoxTestResultsResponse'
         '401':
           description: Unauthorized
       summary: Retrieve Black Box Test Results
@@ -102023,7 +102002,6 @@ paths:
       x-latency-category: responsive
   /short_codes:
     get:
-      description: List short codes
       operationId: ListShortCodes
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -102043,19 +102021,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/ShortCode'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                title: List Short Codes Response
-                type: object
-          description: Successful response with a list of short codes.
+          $ref: '#/components/responses/ListShortCodesResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: List short codes
@@ -102065,21 +102031,12 @@ paths:
       x-latency-category: responsive
   /short_codes/{id}:
     get:
-      description: Retrieve a short code
       operationId: RetrieveShortCode
       parameters:
       - $ref: '#/components/parameters/ShortCodeId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ShortCode'
-                title: Short Code Response
-                type: object
-          description: Successful response with details about a short code.
+          $ref: '#/components/responses/ShortCodeResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Retrieve a short code
@@ -102104,15 +102061,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/ShortCode'
-                title: Short Code Response
-                type: object
-          description: Successful response with details about a short code.
+          $ref: '#/components/responses/ShortCodeResponse'
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
       summary: Update short code
@@ -102130,18 +102079,7 @@ paths:
       - $ref: '#/components/parameters/wireless_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SIMCardAction'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SimCardActionCollectionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102159,14 +102097,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102186,18 +102117,7 @@ paths:
       - $ref: '#/components/parameters/FilterSIMCardId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SimCardDataUsageNotification'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SimCardDataUsageNotificationCollectionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102239,14 +102159,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SimCardDataUsageNotification'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateSimCardDataUsageNotificationResponse'
         '401':
           description: Unauthorized
         default:
@@ -102263,14 +102176,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SimCardDataUsageNotification'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/DeleteSimCardDataUsageNotificationResponse'
         '401':
           description: Unauthorized
         default:
@@ -102286,14 +102192,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SimCardDataUsageNotification'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetSimCardDataUsageNotificationResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -102315,14 +102214,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SimCardDataUsageNotification'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/UpdateSimCardDataUsageNotificationResponse'
         '401':
           description: Unauthorized
         default:
@@ -102356,18 +102248,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SIMCardGroupAction'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SimCardGroupActionCollectionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102385,14 +102266,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroupAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardGroupActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102431,18 +102305,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SearchedSIMCardGroup'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetAllSimCardGroupsResponse'
         '401':
           description: Unauthorized
         default:
@@ -102462,14 +102325,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroup'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateSimCardGroupResponse'
         '401':
           description: Unauthorized
         default:
@@ -102486,14 +102342,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardGroupId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroup'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/DeleteSimCardGroupResponse'
         '401':
           description: Unauthorized
         default:
@@ -102510,14 +102359,7 @@ paths:
       - $ref: '#/components/parameters/IncludeICCIDs'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroup'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetSimCardGroupResponse'
         '401':
           description: Unauthorized
         default:
@@ -102539,14 +102381,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroup'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/UpdateSimCardGroupResponse'
         '401':
           description: Unauthorized
         default:
@@ -102566,14 +102401,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardGroupId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroupAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardGroupActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102591,14 +102419,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardGroupId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroupAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardGroupActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102636,14 +102457,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroupAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardGroupActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102676,14 +102490,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardGroupAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardGroupActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -102717,14 +102524,7 @@ paths:
               type: object
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardOrderPreview'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardOrdersPreviewResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Preview SIM card orders
@@ -102740,18 +102540,7 @@ paths:
       - $ref: '#/components/parameters/wireless_PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SIMCardOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetAllSimCardOrdersResponse'
         '401':
           description: Unauthorized
         default:
@@ -102771,14 +102560,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardOrder'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateSimCardOrderResponse'
         '401':
           description: Unauthorized
         default:
@@ -102795,14 +102577,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardOrder'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetSimCardOrderResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -102833,18 +102608,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SimpleSIMCard'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SearchSimCardsResponse'
         '401':
           description: Unauthorized
         default:
@@ -102882,14 +102646,7 @@ paths:
               type: object
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkSIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/BulkSIMCardActionResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Request bulk disabling voice on SIM cards.
@@ -102925,14 +102682,7 @@ paths:
               type: object
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkSIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/BulkSIMCardActionResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Request bulk enabling voice on SIM cards.
@@ -102966,14 +102716,7 @@ paths:
               type: object
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/BulkSIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/BulkSIMCardActionResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Request bulk setting SIM card public IPs.
@@ -103040,14 +102783,7 @@ paths:
           type: boolean
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCard'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DeleteSimCardResponse'
         '401':
           description: Unauthorized
         default:
@@ -103073,14 +102809,7 @@ paths:
           type: boolean
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCard'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetSimCardResponse'
         '401':
           description: Unauthorized
         default:
@@ -103102,14 +102831,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCard'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UpdateSimCardResponse'
         '401':
           description: Unauthorized
         default:
@@ -103134,14 +102856,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -103168,14 +102883,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -103196,14 +102904,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -103233,14 +102934,7 @@ paths:
           type: string
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -103268,14 +102962,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardAction'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/SIMCardActionResponse'
         '401':
           description: Unauthorized
         default:
@@ -103294,14 +102981,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardActivationCode'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SIMCardActivationCodeResponse'
         '401':
           description: Unauthorized
         default:
@@ -103321,14 +103001,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardDeviceDetails'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SIMCardDeviceDetailsResponse'
         '401':
           description: Unauthorized
         default:
@@ -103347,14 +103020,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SIMCardPublicIP'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/SIMCardPublicIPResponse'
         '401':
           description: Unauthorized
         default:
@@ -103374,18 +103040,7 @@ paths:
       - $ref: '#/components/parameters/SIMCardId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WirelessConnectivityLog'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/WirelessConnectivityLogCollectionResponse'
         '401':
           description: Unauthorized
         default:
@@ -103460,11 +103115,7 @@ paths:
         $ref: '#/components/requestBodies/SiprecConnectorRequest'
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SiprecConnectorResponse'
-          description: Return details of the SIPREC connector.
+          $ref: '#/components/responses/SiprecConnectorResponseBody'
         '422':
           $ref: '#/components/responses/siprec_UnprocessableEntityResponse'
         default:
@@ -103497,11 +103148,7 @@ paths:
       - $ref: '#/components/parameters/SiprecConnectorName'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SiprecConnectorResponse'
-          description: Return details of the SIPREC connector.
+          $ref: '#/components/responses/SiprecConnectorResponseBody'
         '404':
           $ref: '#/components/responses/siprec_NotFoundResponse'
         default:
@@ -103519,11 +103166,7 @@ paths:
         $ref: '#/components/requestBodies/SiprecConnectorRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SiprecConnectorResponse'
-          description: Return details of the SIPREC connector.
+          $ref: '#/components/responses/SiprecConnectorResponseBody'
         '404':
           $ref: '#/components/responses/siprec_NotFoundResponse'
         '422':
@@ -103942,7 +103585,7 @@ paths:
   /storage/migration_source_coverage:
     get:
       deprecated: false
-      description: List Migration Source coverage
+      description: ''
       operationId: ListMigrationSourceCoverage
       parameters: []
       responses:
@@ -103971,7 +103614,7 @@ paths:
   /storage/migration_sources:
     get:
       deprecated: false
-      description: List all Migration Sources
+      description: ''
       operationId: ListMigrationSources
       parameters: []
       responses:
@@ -104029,7 +103672,7 @@ paths:
   /storage/migration_sources/{id}:
     delete:
       deprecated: false
-      description: Delete a Migration Source
+      description: ''
       operationId: DeleteMigrationSource
       parameters:
       - description: Unique identifier for the data migration source.
@@ -104062,7 +103705,7 @@ paths:
       x-latency-category: responsive
     get:
       deprecated: false
-      description: Get a Migration Source
+      description: ''
       operationId: GetMigrationSource
       parameters:
       - description: Unique identifier for the data migration source.
@@ -104096,7 +103739,7 @@ paths:
   /storage/migrations:
     get:
       deprecated: false
-      description: List all Migrations
+      description: ''
       operationId: ListMigrations
       parameters: []
       responses:
@@ -104155,7 +103798,7 @@ paths:
   /storage/migrations/{id}:
     get:
       deprecated: false
-      description: Get a Migration
+      description: ''
       operationId: GetMigration
       parameters:
       - description: Unique identifier for the data migration.
@@ -104189,7 +103832,7 @@ paths:
   /storage/migrations/{id}/actions/stop:
     post:
       deprecated: false
-      description: Stop a Migration
+      description: ''
       operationId: StopMigration
       parameters:
       - description: Unique identifier for the data migration.
@@ -104257,19 +103900,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/SubNumberOrder'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: List Sub Number Orders Response
-                type: object
-          description: Successful response with a list of sub number orders.
+          $ref: '#/components/responses/ListSubNumberOrdersResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104287,7 +103918,6 @@ paths:
       x-latency-category: responsive
   /sub_number_orders/{id}/requirement_group:
     post:
-      description: Update requirement group for a sub number order
       operationId: updateSubNumberOrderRequirementGroup
       parameters:
       - description: The ID of the sub number order
@@ -104359,15 +103989,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SubNumberOrder'
-                title: Sub Number Order Response
-                type: object
-          description: Successful response with details about a sub number order.
+          $ref: '#/components/responses/SubNumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104400,15 +104022,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SubNumberOrder'
-                title: Sub Number Order Response
-                type: object
-          description: Successful response with details about a sub number order.
+          $ref: '#/components/responses/SubNumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104436,15 +104050,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SubNumberOrder'
-                title: Sub Number Order Response
-                type: object
-          description: Successful response with details about a sub number order.
+          $ref: '#/components/responses/SubNumberOrderResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104472,14 +104078,7 @@ paths:
         required: false
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SubNumberOrdersReport'
-                type: object
-          description: Sub number orders report response
+          $ref: '#/components/responses/SubNumberOrdersReportResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104508,14 +104107,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/SubNumberOrdersReport'
-                type: object
-          description: Sub number orders report response
+          $ref: '#/components/responses/SubNumberOrdersReportResponse'
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -104581,19 +104173,7 @@ paths:
       - $ref: '#/components/parameters/telephony-credentials_FilterConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/TelephonyCredential'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                title: Get All Telephony Credential Response
-                type: object
-          description: Successful response with multiple credentials
+          $ref: '#/components/responses/GetAllTelephonyCredentialResponse'
         '400':
           description: Bad request
         '401':
@@ -104618,15 +104198,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TelephonyCredential'
-                title: Telephony Credential Response
-                type: object
-          description: Successful response with details about a credential
+          $ref: '#/components/responses/TelephonyCredentialResponse'
         '422':
           description: Bad request
       summary: Create a credential
@@ -104646,15 +104218,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TelephonyCredential'
-                title: Telephony Credential Response
-                type: object
-          description: Successful response with details about a credential
+          $ref: '#/components/responses/TelephonyCredentialResponse'
         '401':
           description: Unauthorized
         '404':
@@ -104677,15 +104241,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TelephonyCredential'
-                title: Telephony Credential Response
-                type: object
-          description: Successful response with details about a credential
+          $ref: '#/components/responses/TelephonyCredentialResponse'
         '400':
           description: Bad request
         '401':
@@ -104715,15 +104271,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TelephonyCredential'
-                title: Telephony Credential Response
-                type: object
-          description: Successful response with details about a credential
+          $ref: '#/components/responses/TelephonyCredentialResponse'
         '401':
           description: Unauthorized
         '404':
@@ -104962,11 +104510,7 @@ paths:
       - $ref: '#/components/parameters/EndTime_lt'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CallResourceIndex'
-          description: Multiple call resources.
+          $ref: '#/components/responses/GetCallsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch multiple call resources
@@ -104988,11 +104532,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InitiateCallResult'
-          description: Successful response upon initiating a TeXML call.
+          $ref: '#/components/responses/InitiateCallResponse'
         '422':
           $ref: '#/components/responses/call-scripting_UnprocessableEntityResponse'
       summary: Initiate an outbound call
@@ -105010,11 +104550,7 @@ paths:
       - $ref: '#/components/parameters/AccountSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CallResource'
-          description: Call resource.
+          $ref: '#/components/responses/GetCallResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch a call
@@ -105037,11 +104573,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CallResource'
-          description: Call resource.
+          $ref: '#/components/responses/GetCallResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
         '422':
@@ -105060,11 +104592,7 @@ paths:
       - $ref: '#/components/parameters/CallSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlGetCallRecordingsResponseBody'
-          description: Successful Get Call Recordings Response
+          $ref: '#/components/responses/TexmlGetCallRecordingsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch recordings for a call
@@ -105083,11 +104611,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlCreateCallRecordingRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlCreateCallRecordingResponseBody'
-          description: Successful call recording create response
+          $ref: '#/components/responses/TexmlCreateCallRecordingResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Request recording for a call
@@ -105107,11 +104631,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlUpdateCallRecordingRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlCreateCallRecordingResponseBody'
-          description: Successful call recording create response
+          $ref: '#/components/responses/TexmlCreateCallRecordingResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Update recording on a call
@@ -105131,11 +104651,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlCreateSiprecSessionRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlCreateSiprecSessionResponseBody'
-          description: Successful SIPREC session create response
+          $ref: '#/components/responses/TexmlCreateSiprecSessionResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Request siprec session for a call
@@ -105155,11 +104671,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlUpdateSiprecSessionRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlUpdateSiprecSessionResponseBody'
-          description: Successful SIPREC session update response
+          $ref: '#/components/responses/TexmlUpdateSiprecSessionResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Updates siprec session for a call
@@ -105178,11 +104690,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlCreateCallStreamingRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlCreateCallStreamingResponseBody'
-          description: Successful call streaming create response
+          $ref: '#/components/responses/TexmlCreateCallStreamingResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Start streaming media from a call.
@@ -105202,11 +104710,7 @@ paths:
         $ref: '#/components/requestBodies/TexmlUpdateCallStreamingRequest'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlUpdateCallStreamingResponseBody'
-          description: Successful call streaming update response
+          $ref: '#/components/responses/TexmlUpdateCallStreamingResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Update streaming on a call
@@ -105229,11 +104733,7 @@ paths:
       - $ref: '#/components/parameters/DateUpdated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConferenceResourceIndex'
-          description: Multiple conference resources.
+          $ref: '#/components/responses/GetConferencesResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: List conference resources
@@ -105249,11 +104749,7 @@ paths:
       - $ref: '#/components/parameters/ConferenceSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConferenceResource'
-          description: Conference resource.
+          $ref: '#/components/responses/GetConferenceResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch a conference resource
@@ -105275,11 +104771,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConferenceResource'
-          description: Conference resource.
+          $ref: '#/components/responses/GetConferenceResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Update a conference resource
@@ -105295,11 +104787,7 @@ paths:
       - $ref: '#/components/parameters/ConferenceSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ParticipantResourceIndex'
-          description: Multiple participant resources.
+          $ref: '#/components/responses/GetParticipantsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: List conference participants
@@ -105321,11 +104809,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NewParticipantResource'
-          description: New participant resource.
+          $ref: '#/components/responses/DialParticipantResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Dial a new conference participant
@@ -105358,11 +104842,7 @@ paths:
       - $ref: '#/components/parameters/CallSidOrParticipantLabel'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ParticipantResource'
-          description: Participant resource.
+          $ref: '#/components/responses/GetParticipantResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Get conference participant resource
@@ -105385,11 +104865,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ParticipantResource'
-          description: Participant resource.
+          $ref: '#/components/responses/GetParticipantResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Update a conference participant
@@ -105405,11 +104881,7 @@ paths:
       - $ref: '#/components/parameters/ConferenceSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConferenceRecordingResourceIndex'
-          description: Multiple conference recording resources.
+          $ref: '#/components/responses/GetConferenceRecordingsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: List conference recordings
@@ -105425,11 +104897,7 @@ paths:
       - $ref: '#/components/parameters/ConferenceSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlGetCallRecordingsResponseBody'
-          description: Successful Get Call Recordings Response
+          $ref: '#/components/responses/TexmlGetCallRecordingsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch recordings for a conference
@@ -105450,11 +104918,7 @@ paths:
       - $ref: '#/components/parameters/DateUpdated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueueResourceIndex'
-          description: Multiple queue resources.
+          $ref: '#/components/responses/GetQueuesResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: List queue resources
@@ -105475,11 +104939,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueueResource'
-          description: Queue resource.
+          $ref: '#/components/responses/GetQueueResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Create a new queue
@@ -105510,11 +104970,7 @@ paths:
       - $ref: '#/components/parameters/QueueSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueueResource'
-          description: Queue resource.
+          $ref: '#/components/responses/GetQueueResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch a queue resource
@@ -105536,11 +104992,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/QueueResource'
-          description: Queue resource.
+          $ref: '#/components/responses/GetQueueResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Update a queue resource
@@ -105558,11 +105010,7 @@ paths:
       - $ref: '#/components/parameters/TexmlDateCreated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlGetCallRecordingsResponseBody'
-          description: Successful Get Call Recordings Response
+          $ref: '#/components/responses/TexmlGetCallRecordingsResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch multiple recording resources
@@ -105595,11 +105043,7 @@ paths:
       - $ref: '#/components/parameters/RecordingSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlGetCallRecordingResponseBody'
-          description: Retrieves call recording resource.
+          $ref: '#/components/responses/TexmlGetCallRecordingResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch recording resource
@@ -105617,49 +105061,7 @@ paths:
       - $ref: '#/components/parameters/PageSize'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  end:
-                    description: The number of the last element on the page, zero-indexed
-                    example: 1
-                    type: integer
-                  first_page_uri:
-                    description: Relative uri to the first page of the query results
-                    format: uri
-                    type: string
-                  next_page_uri:
-                    description: Relative uri to the next page of the query results
-                    example: /v2/texml/Accounts/61bf923e-5e4d-4595-a110-56190ea18a1b/Transcriptions.json?PageToken=KRWXZPO&PageSize=1
-                    type: string
-                  page:
-                    description: Current page number, zero-indexed.
-                    example: 0
-                    type: integer
-                  page_size:
-                    description: The number of items on the page
-                    example: 20
-                    type: integer
-                  previous_page_uri:
-                    description: Relative uri to the previous page of the query results
-                    format: uri
-                    type: string
-                  start:
-                    description: The number of the first element on the page, zero-indexed.
-                    example: 0
-                    type: integer
-                  transcriptions:
-                    items:
-                      $ref: '#/components/schemas/TexmlRecordingTranscription'
-                    type: array
-                  uri:
-                    description: The URI of the current page.
-                    example: /v2/texml/Accounts/61bf923e-5e4d-4595-a110-56190ea18a1b/Transcriptions.json?PageToken=YTBNAXPI&PageSize=1
-                    type: string
-                title: List Recording Transcriptions Response
-                type: object
-          description: Successful list Recording Transcriptions Response
+          $ref: '#/components/responses/TexmlListRecordingTranscriptionResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: List recording transcriptions
@@ -105693,13 +105095,7 @@ paths:
       - $ref: '#/components/parameters/RecordingTranscriptionSid'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TexmlRecordingTranscription'
-                title: Recording Transcription Response
-                type: object
-          description: Successful get Recording Transcription Response
+          $ref: '#/components/responses/TexmlGetRecordingTranscriptionResponse'
         '404':
           $ref: '#/components/responses/call-scripting_NotFoundResponse'
       summary: Fetch a recording transcription resource
@@ -105747,11 +105143,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InitiateAICallResult'
-          description: Successful response upon initiating an AI call.
+          $ref: '#/components/responses/InitiateAICallResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '422':
@@ -105778,15 +105170,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CreateTeXMLSecretResult'
-                title: Create TeXML Secret request
-                type: object
-          description: Successful response upon creating a TeXML secret.
+          $ref: '#/components/responses/CreateTeXMLSecretResponse'
         '422':
           $ref: '#/components/responses/call-scripting_UnprocessableEntityResponse'
       summary: Create a TeXML secret
@@ -105803,19 +105187,7 @@ paths:
       - $ref: '#/components/parameters/SortApplication'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/TexmlApplication'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/call-scripting_PaginationMeta'
-                title: Get All Texml Applications Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllTexmlApplicationsResponse'
         '400':
           $ref: '#/components/responses/call-scripting_BadRequestResponse'
         '401':
@@ -105840,15 +105212,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TexmlApplication'
-                title: Texml Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/TexmlApplicationResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -105870,15 +105234,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TexmlApplication'
-                title: Texml Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/TexmlApplicationResponse'
         '400':
           $ref: '#/components/responses/call-scripting_BadRequestResponse'
         '401':
@@ -105898,15 +105254,7 @@ paths:
       - $ref: '#/components/parameters/id'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TexmlApplication'
-                title: Texml Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/TexmlApplicationResponse'
         '400':
           $ref: '#/components/responses/call-scripting_BadRequestResponse'
         '401':
@@ -105933,15 +105281,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TexmlApplication'
-                title: Texml Application Response
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/TexmlApplicationResponse'
         '400':
           $ref: '#/components/responses/call-scripting_BadRequestResponse'
         '401':
@@ -106166,18 +105506,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/TrafficPolicyProfile'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetTrafficPolicyProfilesResponse'
         '401':
           description: Unauthorized
         default:
@@ -106239,14 +105568,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TrafficPolicyProfile'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateTrafficPolicyProfileResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -106279,18 +105601,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WirelessPcrfService'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetTrafficPolicyProfileServicesResponse'
         '401':
           description: Unauthorized
         default:
@@ -106307,20 +105618,7 @@ paths:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      id:
-                        description: Identifies the resource.
-                        example: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
-                        format: uuid
-                        type: string
-                    type: object
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/DeleteTrafficPolicyProfileResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -106336,14 +105634,7 @@ paths:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TrafficPolicyProfile'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetTrafficPolicyProfileResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -106406,14 +105697,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/TrafficPolicyProfile'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/UpdateTrafficPolicyProfileResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         '422':
@@ -106437,19 +105721,7 @@ paths:
       - $ref: '#/components/parameters/connections_SortConnection'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/UacConnection'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/connections_PaginationMeta'
-                title: List UAC Connections Response
-                type: object
-          description: Successful response with a list of UAC connections.
+          $ref: '#/components/responses/ListUacConnectionsResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -106478,15 +105750,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UacConnection'
-                title: UAC Connection Response
-                type: object
-          description: Successful response with details about a UAC connection.
+          $ref: '#/components/responses/UacConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -106511,15 +105775,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UacConnection'
-                title: UAC Connection Response
-                type: object
-          description: Successful response with details about a UAC connection.
+          $ref: '#/components/responses/UacConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -106544,15 +105800,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UacConnection'
-                title: UAC Connection Response
-                type: object
-          description: Successful response with details about a UAC connection.
+          $ref: '#/components/responses/UacConnectionResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -106584,15 +105832,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UacConnection'
-                title: UAC Connection Response
-                type: object
-          description: Successful response with details about a UAC connection.
+          $ref: '#/components/responses/UacConnectionResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
         '403':
@@ -106619,66 +105859,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    example:
-                      ip_address: 190.106.106.121
-                      last_registration: '2021-09-28T15:11:02'
-                      port: 37223
-                      record_type: registration_status
-                      sip_username: rogerp
-                      status: Expired
-                      transport: UDP
-                      user_agent: Z 5.4.12 v2.10.13.2-mod
-                    properties:
-                      ip_address:
-                        description: The ip used during the SIP connection
-                        example: 190.106.106.121
-                        type: string
-                      last_registration:
-                        description: ISO 8601 formatted date indicating when the resource
-                          was last updated.
-                        example: '2018-02-02T22:25:27.521Z'
-                        type: string
-                      port:
-                        description: The port of the SIP connection
-                        example: 37223
-                        type: integer
-                      record_type:
-                        description: Identifies the type of the resource.
-                        example: registration_status
-                        type: string
-                      sip_username:
-                        description: The user name of the SIP connection
-                        example: sip_username
-                        type: string
-                      status:
-                        description: The current registration status of your SIP connection
-                        enum:
-                        - Not Applicable
-                        - Not Registered
-                        - Failed
-                        - Expired
-                        - Registered
-                        - Unregistered
-                        type: string
-                      transport:
-                        description: The protocol of the SIP connection
-                        example: TCP
-                        type: string
-                      user_agent:
-                        description: The user agent of the SIP connection
-                        example: Z 5.4.12 v2.10.13.2-mod
-                        type: string
-                    title: Registration Status
-                    type: object
-                title: Registration Status Response
-                type: object
-          description: Successful response with details about a credential connection
-            registration status.
+          $ref: '#/components/responses/RegistrationStatusResponse'
         '400':
           $ref: '#/components/responses/connections_BadRequestResponse'
         '401':
@@ -106980,18 +106161,7 @@ paths:
       - $ref: '#/components/parameters/SortUserAddress'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/UserAddress'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetAllUserAddressResponse'
         '400':
           description: Bad request
         '401':
@@ -107016,14 +106186,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UserAddress'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UserAddressResponse'
         '422':
           description: Bad request
       summary: Creates a user address
@@ -107044,14 +106207,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/UserAddress'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UserAddressResponse'
         '401':
           description: Unauthorized
         '404':
@@ -107082,19 +106238,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    properties:
-                      number_tags:
-                        $ref: '#/components/schemas/UserTagList'
-                      outbound_profile_tags:
-                        $ref: '#/components/schemas/UserTagList'
-                    type: object
-                type: object
-          description: A list of your tags
+          $ref: '#/components/responses/ListUserTagsResponse'
         '401':
           $ref: '#/components/responses/UnauthenticatedResponse'
       summary: List User Tags
@@ -107103,7 +106247,6 @@ paths:
       x-latency-category: responsive
   /v2/mobile_phone_numbers:
     get:
-      description: List Mobile Phone Numbers
       operationId: listMobilePhoneNumbers
       parameters:
       - description: The page number to load
@@ -107138,7 +106281,6 @@ paths:
       x-latency-category: responsive
   /v2/mobile_phone_numbers/{id}:
     get:
-      description: Retrieve a Mobile Phone Number
       operationId: retrieveMobilePhoneNumber
       parameters:
       - description: The ID of the mobile phone number
@@ -107164,7 +106306,6 @@ paths:
       - Mobile Phone Numbers
       x-latency-category: responsive
     patch:
-      description: Update a Mobile Phone Number
       operationId: updateMobilePhoneNumber
       parameters:
       - description: The ID of the mobile phone number
@@ -107197,7 +106338,6 @@ paths:
       x-latency-category: responsive
   /v2/mobile_voice_connections:
     get:
-      description: List Mobile Voice Connections
       operationId: listMobileVoiceConnections
       parameters:
       - description: The page number to load
@@ -107242,7 +106382,6 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     post:
-      description: Create a Mobile Voice Connection
       operationId: createMobileVoiceConnection
       requestBody:
         content:
@@ -107270,7 +106409,6 @@ paths:
       x-latency-category: responsive
   /v2/mobile_voice_connections/{id}:
     delete:
-      description: Delete a Mobile Voice Connection
       operationId: deleteMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107296,7 +106434,6 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     get:
-      description: Retrieve a Mobile Voice Connection
       operationId: retrieveMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107322,7 +106459,6 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     patch:
-      description: Update a Mobile Voice Connection
       operationId: updateMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107357,7 +106493,6 @@ paths:
       x-latency-category: responsive
   /v2/payment/stored_payment_transactions:
     post:
-      description: Create a stored payment transaction
       operationId: createStoredPaymentTransaction
       requestBody:
         content:
@@ -107418,23 +106553,12 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts:
     get:
-      description: List Whatsapp Business Accounts
       operationId: ListWabas
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WabaResponse'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
+          $ref: '#/components/responses/WabasListResponse'
           description: List of Whatsapp Business Accounts
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107444,7 +106568,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}:
     delete:
-      description: Delete a Whatsapp Business Account
       operationId: deleteWaba
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107458,19 +106581,12 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     get:
-      description: Get a single Whatsapp Business Account
       operationId: GetSingleWaba
       parameters:
       - $ref: '#/components/parameters/WabaId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WabaResponse'
-                type: object
+          $ref: '#/components/responses/WabaSingleResponse'
           description: Whatsapp Business Account details
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107480,24 +106596,13 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}/phone_numbers:
     get:
-      description: List phone numbers for a WABA
       operationId: ListWabaPhones
       parameters:
       - $ref: '#/components/parameters/WabaId'
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WhatsappPhoneResponse'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
+          $ref: '#/components/responses/WhatsappPhonesListResponse'
           description: List of phone numbers
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107506,7 +106611,6 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     post:
-      description: Initialize Whatsapp phone number verification
       operationId: InitializeWhatsappVerification
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107527,19 +106631,12 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}/settings:
     get:
-      description: Get WABA settings
       operationId: GetWabaSettings
       parameters:
       - $ref: '#/components/parameters/WabaId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WabaSettings'
-                type: object
+          $ref: '#/components/responses/WabaSettingsResponse'
           description: WABA settings
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107548,7 +106645,6 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     patch:
-      description: Update WABA settings
       operationId: PatchWabaSettings
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107560,13 +106656,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WabaSettings'
-                type: object
+          $ref: '#/components/responses/WabaSettingsResponse'
           description: Updated settings
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107576,7 +106666,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/message_templates:
     get:
-      description: List Whatsapp message templates
       operationId: ListWhatsappTemplates
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -107606,17 +106695,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WhatsappTemplateData'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
+          $ref: '#/components/responses/WhatsappTemplateListResponse'
           description: Whatsapp templates list
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107625,7 +106704,6 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     post:
-      description: Create a Whatsapp message template
       operationId: PostWhatsappTemplate
       requestBody:
         content:
@@ -107635,13 +106713,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappTemplateData'
-                type: object
+          $ref: '#/components/responses/WhatsappTemplateSingleResponse'
           description: Template created
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107651,23 +106723,12 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers:
     get:
-      description: List Whatsapp phone numbers
-      operationId: ListWhatsappPhoneNumbers
+      operationId: ListPhoneNumbers
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WhatsappPhoneResponse'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/messaging_PaginationMeta'
-                type: object
+          $ref: '#/components/responses/WhatsappPhonesListResponse'
           description: Phone numbers
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107677,7 +106738,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}:
     delete:
-      description: Delete a Whatsapp phone number
       operationId: DeleteWhatsappPhoneNumber
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107692,19 +106752,12 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/calling_settings:
     get:
-      description: Get calling settings for a phone number
       operationId: GetWhatsappCallingSettings
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappCallingSettingsData'
-                type: object
+          $ref: '#/components/responses/WhatsappCallingSettingsResponse'
           description: Calling settings
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107713,7 +106766,6 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     patch:
-      description: Enable or disable Whatsapp calling for a phone number
       operationId: PatchWhatsappCallingSettings
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107725,13 +106777,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappCallingSettingsData'
-                type: object
+          $ref: '#/components/responses/WhatsappCallingSettingsResponse'
           description: Updated calling settings
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107741,19 +106787,12 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/profile:
     get:
-      description: Get phone number business profile
       operationId: GetWhatsappProfile
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappProfileData'
-                type: object
+          $ref: '#/components/responses/WhatsappProfileSingleResponse'
           description: Profile
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107762,7 +106801,6 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     patch:
-      description: Update phone number business profile
       operationId: PatchWhatsappProfile
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107774,13 +106812,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappProfileData'
-                type: object
+          $ref: '#/components/responses/WhatsappProfileSingleResponse'
           description: Updated profile
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107790,7 +106822,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/profile/photo:
     delete:
-      description: Delete Whatsapp profile photo
       operationId: DeleteWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107804,7 +106835,6 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     get:
-      description: Get Whatsapp profile photo
       operationId: GetWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107822,7 +106852,6 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     post:
-      description: Upload Whatsapp profile photo
       operationId: PostWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107841,13 +106870,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappProfileData'
-                type: object
+          $ref: '#/components/responses/WhatsappProfileSingleResponse'
           description: Profile with updated photo
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107857,7 +106880,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/resend_verification:
     post:
-      description: Resend verification code
       operationId: ResendWhatsappVerification
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107878,7 +106900,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/verify:
     post:
-      description: Submit verification code for a phone number
       operationId: VerifyWhatsappPhoneNumber
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107899,17 +106920,10 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/user_data:
     get:
-      description: Fetch Whatsapp user data
       operationId: GetWhatsappUserData
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappUserData'
-                type: object
+          $ref: '#/components/responses/WhatsappUserDataResponse'
           description: Whatsapp user data
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107918,7 +106932,6 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     patch:
-      description: Update Whatsapp user data
       operationId: PatchWhatsappUserData
       requestBody:
         content:
@@ -107928,13 +106941,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappUserData'
-                type: object
+          $ref: '#/components/responses/WhatsappUserDataResponse'
           description: Updated user data
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107944,7 +106951,6 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp_message_templates/{id}:
     delete:
-      description: Delete a Whatsapp message template
       operationId: DeleteWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -107958,19 +106964,12 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     get:
-      description: Get a Whatsapp message template by ID
       operationId: GetWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappTemplateData'
-                type: object
+          $ref: '#/components/responses/WhatsappTemplateSingleResponse'
           description: Template details
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -107979,7 +106978,6 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     patch:
-      description: Update a Whatsapp message template
       operationId: PatchWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -107991,13 +106989,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WhatsappTemplateData'
-                type: object
+          $ref: '#/components/responses/WhatsappTemplateSingleResponse'
           description: Updated template
         4XX:
           $ref: '#/components/responses/messaging_GenericErrorResponse'
@@ -108234,7 +107226,6 @@ paths:
       x-latency-category: responsive
   /verifications/by_phone_number/{phone_number}:
     get:
-      description: List verifications by phone number
       operationId: ListVerifications
       parameters:
       - description: The phone number associated with the verifications to retrieve.
@@ -108260,7 +107251,6 @@ paths:
       x-latency-category: responsive
   /verifications/by_phone_number/{phone_number}/actions/verify:
     post:
-      description: Verify verification code by phone number
       operationId: VerifyVerificationCodeByPhoneNumber
       parameters:
       - description: The phone number associated with the verification code being
@@ -108293,7 +107283,6 @@ paths:
       x-latency-category: responsive
   /verifications/call:
     post:
-      description: Trigger Call verification
       operationId: CreateVerificationCall
       requestBody:
         content:
@@ -108327,7 +107316,6 @@ paths:
       x-latency-category: responsive
   /verifications/flashcall:
     post:
-      description: Trigger Flash call verification
       operationId: CreateFlashcallVerification
       requestBody:
         content:
@@ -108361,7 +107349,6 @@ paths:
       x-latency-category: responsive
   /verifications/sms:
     post:
-      description: Trigger SMS verification
       operationId: CreateVerificationSms
       requestBody:
         content:
@@ -108384,7 +107371,6 @@ paths:
       x-latency-category: responsive
   /verifications/whatsapp:
     post:
-      description: Trigger WhatsApp verification
       operationId: CreateWhatsappVerification
       requestBody:
         content:
@@ -108419,7 +107405,6 @@ paths:
       x-latency-category: responsive
   /verifications/{verification_id}:
     get:
-      description: Retrieve verification
       operationId: RetrieveVerification
       parameters:
       - description: The identifier of the verification to retrieve.
@@ -108445,7 +107430,6 @@ paths:
       x-latency-category: responsive
   /verifications/{verification_id}/actions/verify:
     post:
-      description: Verify verification code by ID
       operationId: VerifyVerificationCodeById
       parameters:
       - description: The identifier of the verification to retrieve.
@@ -108591,7 +107575,6 @@ paths:
       x-latency-category: responsive
   /verified_numbers/{phone_number}:
     delete:
-      description: Delete a verified number
       operationId: DeleteVerifiedNumber
       parameters:
       - description: The phone number being deleted.
@@ -108620,7 +107603,6 @@ paths:
       - Verified Numbers
       x-latency-category: responsive
     get:
-      description: Retrieve a verified number
       operationId: GetVerifiedNumber
       parameters:
       - description: The phone number being requested.
@@ -108650,7 +107632,6 @@ paths:
       x-latency-category: responsive
   /verified_numbers/{phone_number}/actions/verify:
     post:
-      description: Submit verification code
       operationId: VerifyVerificationCode
       parameters:
       - description: The phone number being verified.
@@ -108886,7 +107867,6 @@ paths:
       x-latency-category: responsive
   /verify_profiles/{verify_profile_id}:
     delete:
-      description: Delete Verify profile
       operationId: DeleteProfile
       parameters:
       - description: The identifier of the Verify profile to delete.
@@ -108936,7 +107916,6 @@ paths:
       - Verify
       x-latency-category: responsive
     patch:
-      description: Update Verify profile
       operationId: UpdateVerifyProfile
       parameters:
       - description: The identifier of the Verify profile to update.
@@ -109024,18 +108003,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/VirtualCrossConnectCombined'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -109061,14 +108029,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VirtualCrossConnectCombined'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -109085,14 +108046,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VirtualCrossConnectCombined'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -109108,14 +108062,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VirtualCrossConnectCombined'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -109143,14 +108090,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/VirtualCrossConnectCombined'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -109229,18 +108169,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/VirtualCrossConnectCoverage'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/VirtualCrossConnectCoverageListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110066,18 +108995,7 @@ paths:
         style: deepObject
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/webhook_delivery'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMetaSimple'
-                type: object
-          description: A paginated array of webhook_delivery attempts
+          $ref: '#/components/responses/ListWebhookDeliveriesResponse'
         '401':
           description: Unauthorized
         '422':
@@ -110139,18 +109057,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WireguardInterfaceRead'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardInterfaceListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110171,14 +109078,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardInterfaceRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardInterfaceResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -110195,14 +109095,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardInterfaceRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardInterfaceResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110218,14 +109111,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardInterfaceRead'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardInterfaceResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110257,18 +109143,7 @@ paths:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WireguardPeer'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardPeerListResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110289,14 +109164,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardPeer'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardPeerResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -110313,14 +109181,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardPeer'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardPeerResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110336,14 +109197,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardPeer'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardPeerResponse'
         '422':
           $ref: '#/components/responses/netapps_GenericErrorResponse'
         default:
@@ -110365,14 +109219,7 @@ paths:
         required: true
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WireguardPeer'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/WireguardPeerResponse'
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -110429,16 +109276,7 @@ paths:
       - $ref: '#/components/parameters/wireless_PageSize'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WdrReport'
-                    type: array
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetWdrReportsResponse'
         '401':
           description: Unauthorized
         default:
@@ -110461,14 +109299,7 @@ paths:
         required: true
       responses:
         '201':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WdrReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/CreateWdrReportResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -110485,14 +109316,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WdrReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/DeleteWdrReportResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -110508,14 +109332,7 @@ paths:
       - $ref: '#/components/parameters/ResourceId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WdrReport'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/GetWdrReportResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -110635,18 +109452,7 @@ paths:
           type: string
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    items:
-                      $ref: '#/components/schemas/WirelessBlocklist'
-                    type: array
-                  meta:
-                    $ref: '#/components/schemas/PaginationMeta'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetAllWirelessBlocklistsResponse'
         '401':
           description: Unauthorized
         default:
@@ -110696,26 +109502,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                example:
-                  data:
-                    created_at: '2018-02-02T22:25:27.521Z'
-                    id: 6a09cdc3-8948-47f0-aa62-74ac943d6c58
-                    name: North American Wireless Blocklist
-                    record_type: wireless_blocklist
-                    type: country
-                    updated_at: '2018-02-02T22:25:27.521Z'
-                    values:
-                    - CA
-                    - MX
-                    - US
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WirelessBlocklist'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/CreateWirelessBlocklistResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -110732,14 +109519,7 @@ paths:
       - $ref: '#/components/parameters/WirelessBlocklistId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WirelessBlocklist'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/DeleteWirelessBlocklistResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -110755,14 +109535,7 @@ paths:
       - $ref: '#/components/parameters/WirelessBlocklistId'
       responses:
         '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WirelessBlocklist'
-                type: object
-          description: Successful Response
+          $ref: '#/components/responses/GetWirelessBlocklistResponse'
         '404':
           $ref: '#/components/responses/wireless_ResourceNotFound'
         default:
@@ -110801,14 +109574,7 @@ paths:
         required: true
       responses:
         '202':
-          content:
-            application/json:
-              schema:
-                properties:
-                  data:
-                    $ref: '#/components/schemas/WirelessBlocklist'
-                type: object
-          description: Successful response
+          $ref: '#/components/responses/UpdateWirelessBlocklistResponse'
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:


### PR DESCRIPTION
## Summary
Reverts the two AI-agent-readiness experiments:
- **#195** — dedup + inline response schemas
- **#196** — shorten 27 operationIds >64 chars

Net effect on the spec:
- Original (long) operationIds restored → **27** operationIds back over 64 chars
- Response schemas de-inlined → **566** 2xx responses back to `$ref`
- Parameter descriptions from **#197** are preserved (not reverted)

## Why
The `function-calling-compat` orank check (#196's target) is a **spec-size limitation**, not a content-quality issue — large specs (Stripe, Twilio, Vercel) all fail it identically while only sub-3MB specs pass. #196's operationId shortening had **no measured score impact** and diverged operationIds from the canonical openapi-internal source (where they drive generated SDK method names).

## ⚠️ Score consequence
Reverting **#195 drops `response-schema-coverage` back from 2/2 → 1/2** — that was the one *verified* orank win (90% typed responses, confirmed in the latest scan). Reverting #196 has no score impact.

Both files (`spec3.json`, `spec3.yml`) validated.