### PR TITLE
Add LLM function-calling compatibility validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,18 @@ npx @stoplight/spectral-cli@latest lint openapi/spec3.json
 npx @redocly/cli@latest preview-docs openapi/spec3.json
 ```
 
+This repo ships a focused, read-only function-calling ruleset in `redocly.yaml`, so the `redocly` command above auto-applies it. A convenience wrapper is also available:
+
+```bash
+# Read-only function-calling compatibility check (uses redocly.yaml)
+./scripts/validate-function-calling.sh
+```
+
 Do not run formatters, codegen, or "fix" commands against the spec files — they will be overwritten on the next sync from the internal source-of-truth.
 
 ## Testing Strategy
 - Validate spec parseability locally before opening a PR (see commands above).
-- Lint operations for unique `operationId`s, typed parameters, error schemas, and pagination consistency.
+- Lint operations for unique `operationId`s, typed parameters, error schemas, and pagination consistency. This is codified in `redocly.yaml`; see [`docs/agent-function-calling.md`](docs/agent-function-calling.md) for the full function-calling contract and current status.
 - If a lint failure points at a generated file, the fix belongs in the internal source repo, not here.
 
 ## PR Expectations

--- a/docs/agent-function-calling.md
+++ b/docs/agent-function-calling.md
@@ -1,0 +1,96 @@
+# Function-Calling Compatibility
+
+The Telnyx OpenAPI spec (`openapi/spec3.json`) is consumed not only by SDK
+generators but by **LLM function-calling / tool-use** pipelines (OpenAI tools,
+Anthropic tools, LangChain, and Ora's API-readiness scanner). Those pipelines
+convert each OpenAPI **operation** into exactly one callable **tool**, so a few
+properties have to hold for the conversion to succeed.
+
+This document describes the contract, how to validate it, and the current
+status. The contract is enforced by the ruleset in
+[`redocly.yaml`](../redocly.yaml).
+
+## Why it matters
+
+When an agent runtime ingests this spec, each operation becomes a function the
+model can call:
+
+| OpenAPI element        | Function-calling role                     |
+| ---------------------- | ----------------------------------------- |
+| `operationId`          | Tool/function **name** (must be unique)   |
+| `summary`/`description`| Tool description used for **selection**   |
+| `parameters[]`         | Function **arguments** (typed + described)|
+| `requestBody.schema`   | Function **arguments** (body)             |
+| `2xx` response schema  | Result the agent **parses**               |
+| `4xx`/error schema     | Structured **error recovery**             |
+
+If two operations share an `operationId`, they collide into one function name
+and most generators silently drop one of the tools. If a parameter has no
+schema, the runtime cannot type the argument. If an operation has no summary,
+the model cannot reliably decide when to call it.
+
+## The contract
+
+Enforced as `error` (a regression here breaks tool generation):
+
+- **`spec`** — the document is structurally valid OpenAPI and parses.
+- **`operation-operationId`** — every operation exposes a tool name.
+- **`operation-operationId-unique`** — tool names are globally unique.
+- **`operation-operationId-url-safe`** — tool names are safe identifiers.
+- **`operation-summary`** — every operation has a concise, selectable summary.
+- **`operation-parameters-unique`** — no duplicate argument names.
+- **`operation-2xx-response`** — a typed success result exists.
+- **`no-identical-paths`** / **`path-declaration-must-exist`** — unambiguous routing.
+
+Tracked as `warn` (enhancements, already broadly satisfied):
+
+- **`operation-description`** — long-form description in addition to the summary.
+- **`operation-4xx-response`** — a modelled error response for recovery.
+- **`rule/parameter-has-description`** — every parameter carries a description.
+
+## How to validate (read-only)
+
+```bash
+# From the repo root — auto-discovers redocly.yaml:
+npx @redocly/cli@latest lint openapi/spec3.json
+
+# Or the convenience wrapper:
+./scripts/validate-function-calling.sh
+```
+
+Both commands are read-only and never modify spec files.
+
+## Current status (OpenAPI 3.1.0)
+
+A scan of `openapi/spec3.json` shows the spec is in strong shape for
+function-calling:
+
+- **734 paths / 1082 operations**; every operation has an `operationId` and a
+  `summary`.
+- Every inline parameter is typed (has a `schema`/`content`) and described.
+- Every request body is typed; every operation has a `2xx` response.
+
+### Known gap: one duplicate `operationId`
+
+The error-level ruleset currently surfaces exactly one violation:
+
+- `operationId: ListPhoneNumbers` is used by **both**:
+  - `GET /phone_numbers`
+  - `GET /v2/whatsapp/phone_numbers`
+
+These two operations collapse into a single `ListPhoneNumbers` tool, so one of
+them is dropped by function-calling generators. The fix is to give the WhatsApp
+operation a distinct id (for example `ListWhatsappPhoneNumbers`).
+
+**This must be fixed in the internal source-of-truth, not here.** The specs
+under `openapi/` are generated; a hand-edit would be overwritten on the next
+sync (see [`AGENTS.md`](../AGENTS.md)). Once the source rename lands and syncs,
+this lint passes clean.
+
+## References
+
+- Ruleset: [`redocly.yaml`](../redocly.yaml)
+- Repo agent guide: [`AGENTS.md`](../AGENTS.md)
+- Cross-repo plan (Phase 4 — OpenAPI & Function Calling):
+  https://github.com/team-telnyx/win-the-bot/blob/main/cases/ora-agent-readiness/cross-repo-execution-plan.md
+- Live Ora score: https://ora.run/score/telnyx.com

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,57 @@
+# Redocly configuration for the Telnyx OpenAPI spec.
+#
+# Scope: a focused, read-only ruleset that validates the spec's compatibility
+# with LLM function-calling / tool-use formats (OpenAI tools, Anthropic tools,
+# and similar). Each OpenAPI operation maps to exactly one callable "tool", so
+# the properties below are what agent tool-generators depend on.
+#
+# This config does NOT modify any spec file. The specs under openapi/ are
+# GENERATED from an internal source-of-truth (see AGENTS.md) — when a rule below
+# flags a generated file, the fix belongs in the internal generator, then syncs
+# to this repo. Do not hand-edit openapi/spec*.{json,yml}.
+#
+# Run:  npx @redocly/cli@latest lint openapi/spec3.json
+#   or: ./scripts/validate-function-calling.sh
+#
+# See docs/agent-function-calling.md for the full contract and current status.
+
+apis:
+  telnyx@v2:
+    root: openapi/spec3.json
+
+rules:
+  # --- Core function-calling requirements (operation -> one unique tool) ---
+  # A stable, unique, URL/identifier-safe operationId becomes the tool name.
+  # Duplicate operationIds collide into one function name and silently drop a
+  # tool in most generators — the single most important check here.
+  operation-operationId: error
+  operation-operationId-unique: error
+  operation-operationId-url-safe: error
+  # A concise summary is the tool's selectable description.
+  operation-summary: error
+  # Argument names (parameters) must be unique within a tool.
+  operation-parameters-unique: error
+  # A typed success response lets agents parse tool output.
+  operation-2xx-response: error
+  # Avoid ambiguous routing that confuses path/operation mapping.
+  no-identical-paths: error
+  path-declaration-must-exist: error
+
+  # --- Tracked, not yet 100% across all operations (advisory) ---
+  # Long-form descriptions improve tool selection; every operation already has a
+  # summary, so this is an enhancement rather than a blocker.
+  operation-description: warn
+  # A modelled error response improves agent error-recovery.
+  operation-4xx-response: warn
+  # Every parameter should carry a description so agents pick arguments well.
+  rule/parameter-has-description:
+    subject:
+      type: Parameter
+      property: description
+    assertions:
+      defined: true
+      minLength: 1
+    severity: warn
+    message: >-
+      Function-calling: parameter is missing a description. Agents rely on
+      parameter descriptions to choose argument values correctly.

--- a/scripts/validate-function-calling.sh
+++ b/scripts/validate-function-calling.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# Read-only function-calling compatibility check for the Telnyx OpenAPI spec.
+#
+# Lints the spec against the ruleset in ../redocly.yaml, which asserts the
+# properties LLM function-calling / tool-use generators depend on (unique
+# operationIds, typed + described parameters, summaries, typed responses).
+#
+# This script NEVER modifies the spec. The specs under openapi/ are generated
+# from an internal source-of-truth (see AGENTS.md); fix lint findings there.
+#
+# Usage:
+#   ./scripts/validate-function-calling.sh [path-to-spec]   # default: openapi/spec3.json
+#
+# A non-zero exit means a function-calling-relevant rule failed. See
+# docs/agent-function-calling.md for the contract and any known gaps.
+set -eu
+
+SPEC="${1:-openapi/spec3.json}"
+
+if [ ! -f "$SPEC" ]; then
+  echo "error: spec not found: $SPEC" >&2
+  exit 2
+fi
+
+echo "Linting '$SPEC' for LLM function-calling compatibility (read-only)..."
+exec npx --yes @redocly/cli@latest lint "$SPEC"


### PR DESCRIPTION
## Summary

Addresses the Ora/orank **"Function calling compatibility"** finding for `telnyx.com` (_"API spec found but couldn't validate function calling compatibility"_ → _"Ensure API endpoints have unique operation IDs, typed schemas, and descriptions compatible with LLM function-calling formats"_).

Per this repo's `AGENTS.md`, the specs under `openapi/` are **generated** and must not be hand-edited. This PR therefore follows the sanctioned path from the [cross-repo execution plan](https://github.com/team-telnyx/win-the-bot/blob/main/cases/ora-agent-readiness/cross-repo-execution-plan.md) (Phase 4 → item #12): **add a small, read-only validation that codifies the function-calling contract and documents the generated-source constraint.** No spec files are modified.

Each OpenAPI operation maps to exactly one callable LLM tool, so the ruleset asserts the properties tool-generators (OpenAI tools, Anthropic tools, Ora's scanner) depend on.

## What's included

- **`redocly.yaml`** — a focused function-calling ruleset (auto-discovered by `npx @redocly/cli lint`). `error`: unique + URL-safe `operationId`, per-op `summary`, unique parameters, typed `2xx` response, unambiguous paths. `warn` (enhancements): long-form descriptions, modelled `4xx`, parameter descriptions.
- **`scripts/validate-function-calling.sh`** — read-only wrapper around the lint.
- **`docs/agent-function-calling.md`** — the contract, how to validate, and current status.
- **`AGENTS.md`** — pointers to the ruleset/script/docs.

## Verification

Ran locally (read-only):

```
$ npx @redocly/cli@latest lint openapi/spec3.json
❌ Validation failed with 1 error and 195 warnings.
```

- **1 error** — `operation-operationId-unique`: `operationId: ListPhoneNumbers` is duplicated across `GET /phone_numbers` and `GET /v2/whatsapp/phone_numbers`. The two collapse into one tool, so a generator drops one of them. **This is the concrete function-calling defect.**
- **195 warnings** — `operation-description` only (every operation already has a `summary`; these are advisory long-form descriptions). Zero parameter/`4xx`/`summary`/`operationId`/`2xx` violations, confirming the spec is otherwise function-calling-clean (734 paths / 1082 operations, OpenAPI 3.1.0).

## Known gap (fix at the internal source-of-truth)

The duplicate `ListPhoneNumbers` must be renamed in the internal generator (e.g. `ListWhatsappPhoneNumbers` for the WhatsApp operation), then synced to `master`. It is **not** hand-edited here — a hand-edit would be overwritten on the next sync. Once the source rename lands, this lint passes clean.

## Notes

- Intentionally scoped to function-calling. The `struct` (OpenAPI 3.1 structural) rule was deliberately excluded — it surfaces a separate, unrelated batch of `nullable`-in-3.1 deviations that also belong to the internal source, and would bury the one actionable function-calling finding. Tracking that separately.
- cc @nicktimko (maintainer) for review.

🤖 Part of the Win the Bot / Ora agent-readiness initiative.