### PR TITLE
fix(openapi): re-apply LLM function-calling compatibility fixes lost in #206 sync

### DIFF
--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -68722,6 +68722,7 @@ paths:
       x-latency-category: responsive
   /10dlc/brand/{brandId}/2faEmail:
     post:
+      description: Resend brand 2FA email
       operationId: ResendBrand2faEmail
       parameters:
       - description: Unique identifier of the brand.
@@ -69166,6 +69167,7 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/usecase/cost:
     get:
+      description: Get Campaign Cost
       operationId: GetCampaignCost
       parameters:
       - description: Filter results by usecase.
@@ -69437,6 +69439,7 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/{campaignId}/osr/attributes:
     get:
+      description: Get OSR campaign attributes
       operationId: GetCampaignOsrAttributes
       parameters:
       - description: Unique identifier of the campaign.
@@ -69472,6 +69475,7 @@ paths:
       x-latency-category: responsive
   /10dlc/campaign/{campaignId}/sharing:
     get:
+      description: Get Sharing Status
       operationId: GetCampaignSharingStatus
       parameters:
       - description: ID of the campaign in question
@@ -69589,6 +69593,7 @@ paths:
       x-latency-category: responsive
   /10dlc/enum/{endpoint}:
     get:
+      description: Get Enum
       operationId: GetEnumEndpoint
       parameters:
       - description: Unique identifier of the endpoint.
@@ -69694,6 +69699,7 @@ paths:
       x-latency-category: responsive
   /10dlc/partnerCampaign/{campaignId}/sharing:
     get:
+      description: Get Sharing Status
       operationId: GetPartnerCampaignSharingStatus
       parameters:
       - description: ID of the campaign in question
@@ -69978,6 +69984,7 @@ paths:
       x-latency-category: responsive
   /10dlc/phone_number_campaigns:
     get:
+      description: List phone number campaigns
       operationId: GetAllPhoneNumberCampaigns
       parameters:
       - description: Number of records to return per page.
@@ -70030,6 +70037,7 @@ paths:
       - Phone Number Campaigns
       x-latency-category: responsive
     post:
+      description: Create New Phone Number Campaign
       operationId: CreatePhoneNumberCampaign
       parameters: []
       requestBody:
@@ -70102,6 +70110,7 @@ paths:
       - Phone Number Campaigns
       x-latency-category: responsive
     put:
+      description: Create New Phone Number Campaign
       operationId: PutPhoneNumberCampaign
       parameters:
       - description: Unique identifier of the phone number.
@@ -70132,6 +70141,7 @@ paths:
       x-latency-category: responsive
   /access_ip_address:
     get:
+      description: List all Access IP Addresses
       operationId: ListAccessIpAddresses
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -70261,6 +70271,7 @@ paths:
       - IP Addresses
       x-latency-category: responsive
     post:
+      description: Create new Access IP Address
       operationId: CreateAccessIpAddress
       requestBody:
         content:
@@ -70287,6 +70298,7 @@ paths:
       x-latency-category: responsive
   /access_ip_address/{access_ip_address_id}:
     delete:
+      description: Delete access IP address
       operationId: DeleteAccessIpAddress
       parameters:
       - description: Unique identifier of the access ip address.
@@ -70313,6 +70325,7 @@ paths:
       - IP Addresses
       x-latency-category: responsive
     get:
+      description: Retrieve an access IP address
       operationId: GetAccessIpAddress
       parameters:
       - description: Unique identifier of the access ip address.
@@ -70340,6 +70353,7 @@ paths:
       x-latency-category: responsive
   /access_ip_ranges:
     get:
+      description: List all Access IP Ranges
       operationId: ListAccessIpRanges
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -70495,6 +70509,7 @@ paths:
       - IP Ranges
       x-latency-category: responsive
     post:
+      description: Create new Access IP Range
       operationId: CreateAccessIPRange
       requestBody:
         content:
@@ -70521,6 +70536,7 @@ paths:
       x-latency-category: responsive
   /access_ip_ranges/{access_ip_range_id}:
     delete:
+      description: Delete access IP ranges
       operationId: DeleteAccessIpRange
       parameters:
       - description: Unique identifier of the access ip range.
@@ -70779,6 +70795,9 @@ paths:
       x-latency-category: responsive
   /addresses/{id}/actions/accept_suggestions:
     post:
+      description: Accepts this address suggestion as a new emergency address for
+        Operator Connect and finishes the uploads of the numbers associated with it
+        to Microsoft.
       operationId: acceptAddressSuggestions
       parameters:
       - description: The UUID of the address that should be accepted.
@@ -70821,6 +70840,7 @@ paths:
       x-latency-category: responsive
   /advanced_orders:
     get:
+      description: List Advanced Orders
       operationId: list_advanced_orders_v2
       responses:
         '200':
@@ -70849,6 +70869,7 @@ paths:
       - Advanced Number Orders
       x-latency-category: responsive
     post:
+      description: Create Advanced Order
       operationId: create_advanced_order_v2
       requestBody:
         content:
@@ -70879,6 +70900,7 @@ paths:
       x-latency-category: responsive
   /advanced_orders/{advanced-order-id}/requirement_group:
     patch:
+      description: Update Advanced Order
       operationId: update_advanced_order_v2
       parameters:
       - description: Unique identifier of the advanced order.
@@ -70918,6 +70940,7 @@ paths:
       x-latency-category: responsive
   /advanced_orders/{order_id}:
     get:
+      description: Get Advanced Order
       operationId: get_advanced_order_v2
       parameters:
       - description: Unique identifier of the order.
@@ -71027,6 +71050,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/tags:
     get:
+      description: Get All Tags
       operationId: get_all_assistant_tags
       responses:
         '200':
@@ -71169,7 +71193,7 @@ paths:
     get:
       description: Retrieves paginated history of test runs for a specific test suite
         with filtering options
-      operationId: get_test_suite_runs_for_test_public_assistants_tests_test_suites__suite_name__runs_get
+      operationId: ListTestSuiteRuns
       parameters:
       - description: Name of the suite.
         in: path
@@ -71237,7 +71261,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Executes all tests within a specific test suite as a batch operation
-      operationId: trigger_test_suite_runs_public_assistants_tests_test_suites__suite_name__runs_post
+      operationId: TriggerTestSuiteRuns
       parameters:
       - description: Name of the suite.
         in: path
@@ -71365,7 +71389,7 @@ paths:
     get:
       description: Retrieves paginated execution history for a specific assistant
         test with filtering options
-      operationId: get_test_runs_for_test_public_assistants_tests__test_id__runs_get
+      operationId: ListTestRuns
       parameters:
       - description: Unique identifier of the test.
         in: path
@@ -71620,7 +71644,7 @@ paths:
 
 
         Removes all canary deploy configurations for the specified assistant.'
-      operationId: delete_canary_deploy_assistants__assistant_id__canary_deploys_delete
+      operationId: DeleteCanaryDeploy
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -71684,7 +71708,7 @@ paths:
         traffic
 
         percentages for A/B testing or gradual rollouts of assistant versions.'
-      operationId: create_canary_deploy_assistants__assistant_id__canary_deploys_post
+      operationId: CreateCanaryDeploy
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -71721,7 +71745,7 @@ paths:
         \nUpdates the existing canary deploy configuration with new version IDs and\
         \ percentages.\n  All old versions and percentages are replaces by new ones\
         \ from this request."
-      operationId: update_canary_deploy_assistants__assistant_id__canary_deploys_put
+      operationId: UpdateCanaryDeploy
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72042,6 +72066,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tags:
     post:
+      description: Add Assistant Tag
       operationId: add_assistant_tag
       parameters:
       - description: Unique identifier of the assistant.
@@ -72076,6 +72101,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tags/{tag}:
     delete:
+      description: Remove Assistant Tag
       operationId: remove_assistant_tag
       parameters:
       - description: Unique identifier of the assistant.
@@ -72140,6 +72166,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tools/{tool_id}:
     delete:
+      description: Remove Assistant Tool
       operationId: remove_assistant_tool
       parameters:
       - description: Unique identifier of the assistant.
@@ -72173,6 +72200,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     put:
+      description: Add Assistant Tool
       operationId: add_assistant_tool
       parameters:
       - description: Unique identifier of the assistant.
@@ -72208,7 +72236,7 @@ paths:
   /ai/assistants/{assistant_id}/tools/{tool_id}/test:
     post:
       description: Test a webhook tool for an assistant
-      operationId: test_assistant_tool_public_assistants__assistant_id__tools__tool_id__test_post
+      operationId: TestAssistantTool
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72250,7 +72278,7 @@ paths:
     get:
       description: Retrieves all versions of a specific assistant with complete configuration
         and metadata
-      operationId: get_assistant_versions_public_assistants__assistant_id__versions_get
+      operationId: ListAssistantVersions
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72281,7 +72309,7 @@ paths:
     delete:
       description: Permanently removes a specific version of an assistant. Can not
         delete main version
-      operationId: delete_assistant_version_public_assistants__assistant_id__versions__version_id__delete
+      operationId: DeleteAssistantVersion
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72313,7 +72341,7 @@ paths:
     get:
       description: Retrieves a specific version of an assistant by assistant_id and
         version_id
-      operationId: get_assistant_version_public_assistants__assistant_id__versions__version_id__get
+      operationId: GetAssistantVersion
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72355,7 +72383,7 @@ paths:
     post:
       description: Updates the configuration of a specific assistant version. Can
         not update main version
-      operationId: update_assistant_version_public_assistants__assistant_id__versions__version_id__post
+      operationId: UpdateAssistantVersion
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72399,7 +72427,7 @@ paths:
       description: Promotes a specific version to be the main/current version of the
         assistant. This will delete any existing canary deploy configuration and send
         all live production traffic to this version.
-      operationId: promote_assistant_version_public_assistants__assistant_id__versions__version_id__promote_post
+      operationId: PromoteAssistantVersion
       parameters:
       - description: Unique identifier of the assistant.
         in: path
@@ -72502,6 +72530,7 @@ paths:
       x-latency-category: responsive
   /ai/clusters:
     get:
+      description: List all clusters
       operationId: list_all_requested_clusters_public_text_clusters_get
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -72568,6 +72597,7 @@ paths:
       x-latency-category: responsive
   /ai/clusters/{task_id}:
     delete:
+      description: Delete a cluster
       operationId: delete_cluster_by_task_id_public_text_clusters__task_id__delete
       parameters:
       - description: Unique identifier of the task.
@@ -72591,6 +72621,7 @@ paths:
       - Clusters
       x-latency-category: responsive
     get:
+      description: Fetch a cluster
       operationId: fetch_cluster_by_task_id_public_text_clusters__task_id__get
       parameters:
       - description: Unique identifier of the task.
@@ -72637,7 +72668,8 @@ paths:
       x-latency-category: responsive
   /ai/clusters/{task_id}/graph:
     get:
-      operationId: fetch_cluster_image_by_task_id_public_text_clusters__task_id__image_get
+      description: Fetch a cluster visualization
+      operationId: GetClusterImage
       parameters:
       - description: Unique identifier of the task.
         in: path
@@ -73503,7 +73535,7 @@ paths:
     delete:
       description: Deletes an entire bucket's embeddings and disables the bucket for
         AI-use, returning it to normal storage pricing.
-      operationId: embedding_bucket_files_public_embedding_buckets__bucket_name__delete
+      operationId: DeleteEmbeddingBucket
       parameters:
       - description: Name of the bucket.
         in: path
@@ -73842,7 +73874,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get user setup integrations
-      operationId: get_user_integration_by_id_public_integrations_connections__user_connection_id__get
+      operationId: GetUserIntegration
       parameters:
       - description: The connection id
         in: path
@@ -74408,7 +74440,7 @@ paths:
   /ai/missions/{mission_id}/knowledge-bases/{knowledge_base_id}:
     delete:
       description: Delete a knowledge base from a mission
-      operationId: delete_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: DeleteMissionKnowledgeBase
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74439,7 +74471,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific knowledge base by ID
-      operationId: get_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: GetMissionKnowledgeBase
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74473,7 +74505,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update a knowledge base definition
-      operationId: put_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
+      operationId: PutMissionKnowledgeBase
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74563,7 +74595,7 @@ paths:
   /ai/missions/{mission_id}/mcp-servers/{mcp_server_id}:
     delete:
       description: Delete an MCP server from a mission
-      operationId: delete_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: DeleteMissionMcpServer
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74594,7 +74626,7 @@ paths:
       x-latency-category: responsive
     get:
       description: Get a specific MCP server by ID
-      operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: GetMissionMcpServer
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74628,7 +74660,7 @@ paths:
       x-latency-category: responsive
     put:
       description: Update an MCP server definition
-      operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_server_id
+      operationId: PutMissionMcpServer
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -74998,7 +75030,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/events/{event_id}:
     get:
       description: Get details of a specific event
-      operationId: get_public_missions_missions_mission_id_runs_run_id_events_event_id
+      operationId: GetMissionRunEvent
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75206,7 +75238,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/plan/steps/{step_id}:
     get:
       description: Get details of a specific plan step
-      operationId: get_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
+      operationId: GetMissionRunStep
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75250,7 +75282,7 @@ paths:
       x-latency-category: responsive
     patch:
       description: Update the status of a plan step
-      operationId: patch_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
+      operationId: UpdateMissionRunStep
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75339,7 +75371,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents:
     get:
       description: List all Telnyx agents linked to a run
-      operationId: get_public_missions_missions_mission_id_runs_run_id_telnyx_agents
+      operationId: ListMissionRunAgents
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75376,7 +75408,7 @@ paths:
       x-latency-category: responsive
     post:
       description: Link a Telnyx AI agent (voice/messaging) to a run
-      operationId: post_public_missions_missions_mission_id_runs_run_id_telnyx_agents
+      operationId: CreateMissionRunAgent
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75420,7 +75452,7 @@ paths:
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents/{telnyx_agent_id}:
     delete:
       description: Unlink a Telnyx agent from a run
-      operationId: delete_public_missions_missions_mission_id_runs_run_id_telnyx_agents_telnyx_agent_id
+      operationId: DeleteMissionRunAgent
       parameters:
       - description: Unique identifier of the mission.
         in: path
@@ -75940,6 +75972,7 @@ paths:
       x-latency-category: responsive
   /ai/tools:
     get:
+      description: List Tools
       operationId: list_tools
       parameters:
       - description: Filter results by filter type.
@@ -75993,6 +76026,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     post:
+      description: Create Tool
       operationId: create_tool_post
       requestBody:
         content:
@@ -76019,6 +76053,7 @@ paths:
       x-latency-category: responsive
   /ai/tools/{tool_id}:
     delete:
+      description: Delete Tool
       operationId: delete_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -76045,6 +76080,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     get:
+      description: Get Tool
       operationId: get_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -76072,6 +76108,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     patch:
+      description: Update Tool
       operationId: update_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -76540,6 +76577,7 @@ paths:
       x-latency-category: responsive
   /available_phone_number_blocks:
     get:
+      description: List available phone number blocks
       operationId: ListAvailablePhoneNumberBlocks
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -76602,6 +76640,7 @@ paths:
       x-latency-category: responsive
   /available_phone_numbers:
     get:
+      description: List available phone numbers
       operationId: ListAvailablePhoneNumbers
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -76726,6 +76765,7 @@ paths:
       x-latency-category: responsive
   /balance:
     get:
+      description: Get user balance details
       operationId: GetUserBalance
       responses:
         '200':
@@ -76752,7 +76792,7 @@ paths:
   /billing_groups:
     get:
       deprecated: false
-      description: ''
+      description: List all billing groups
       operationId: ListBillingGroups
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -76800,7 +76840,7 @@ paths:
       x-latency-category: responsive
     post:
       deprecated: false
-      description: ''
+      description: Create a billing group
       operationId: CreateBillingGroup
       requestBody:
         content:
@@ -76834,7 +76874,7 @@ paths:
   /billing_groups/{id}:
     delete:
       deprecated: false
-      description: ''
+      description: Delete a billing group
       operationId: DeleteBillingGroup
       parameters:
       - description: The id of the billing group
@@ -76872,7 +76912,7 @@ paths:
       x-latency-category: responsive
     get:
       deprecated: false
-      description: ''
+      description: Get a billing group
       operationId: GetBillingGroup
       parameters:
       - description: The id of the billing group
@@ -76906,7 +76946,7 @@ paths:
       x-latency-category: responsive
     patch:
       deprecated: false
-      description: ''
+      description: Update a billing group
       operationId: UpdateBillingGroup
       parameters:
       - description: The id of the billing group
@@ -78992,6 +79032,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/suppression_start:
     post:
+      description: Noise Suppression Start (BETA)
       operationId: noiseSuppressionStart
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -79023,6 +79064,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/suppression_stop:
     post:
+      description: Noise Suppression Stop (BETA)
       operationId: noiseSuppressionStop
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -79390,6 +79432,7 @@ paths:
       x-latency-category: responsive
   /comments:
     get:
+      description: Retrieve all comments
       operationId: ListComments
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -79441,6 +79484,7 @@ paths:
       - Phone Number Orders
       x-latency-category: responsive
     post:
+      description: Create a comment
       operationId: CreateComment
       requestBody:
         content:
@@ -79476,6 +79520,7 @@ paths:
       x-latency-category: responsive
   /comments/{id}:
     get:
+      description: Retrieve a comment
       operationId: RetrieveComment
       parameters:
       - description: The comment ID.
@@ -79512,6 +79557,7 @@ paths:
       x-latency-category: responsive
   /comments/{id}/read:
     patch:
+      description: Mark a comment as read
       operationId: MarkCommentRead
       parameters:
       - description: The comment ID.
@@ -83945,6 +83991,7 @@ paths:
       x-latency-category: responsive
   /external_connections/{id}/locations/{location_id}:
     patch:
+      description: Update a location's static emergency address
       operationId: updateLocation
       parameters:
       - description: The ID of the external connection
@@ -84536,7 +84583,7 @@ paths:
       x-latency-category: responsive
   /faxes:
     get:
-      description: ''
+      description: View a list of faxes
       operationId: ListFaxes
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -84714,6 +84761,7 @@ paths:
       x-latency-category: responsive
   /faxes/{id}:
     delete:
+      description: Delete a fax
       operationId: DeleteFax
       parameters:
       - description: The unique identifier of a fax.
@@ -84735,6 +84783,7 @@ paths:
       - Programmable Fax Commands
       x-latency-category: responsive
     get:
+      description: View a fax
       operationId: ViewFax
       parameters:
       - description: The unique identifier of a fax.
@@ -85208,6 +85257,7 @@ paths:
   /global_ip_assignment_health:
     description: Global IP Assignment Health Check Metrics over time
     get:
+      description: Global IP Assignment Health Check Metrics
       operationId: GetGlobalIpAssignmentHealth
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85397,6 +85447,7 @@ paths:
   /global_ip_assignments_usage:
     description: Global IP Assignment Usage Metrics over time
     get:
+      description: Global IP Assignment Usage Metrics
       operationId: GetGlobalIpAssignmentUsage
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85581,6 +85632,7 @@ paths:
   /global_ip_latency:
     description: Global IP Latency Metrics over time
     get:
+      description: Global IP Latency Metrics
       operationId: GetGlobalIpLatency
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -85651,6 +85703,7 @@ paths:
   /global_ip_usage:
     description: Global IP Usage Metrics over time
     get:
+      description: Global IP Usage Metrics
       operationId: GetGlobalIpUsage
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -86863,7 +86916,7 @@ paths:
   /ledger_billing_group_reports:
     post:
       deprecated: false
-      description: ''
+      description: Create a ledger billing group report
       operationId: CreateBillingGroupReport
       parameters: []
       requestBody:
@@ -86902,7 +86955,7 @@ paths:
   /ledger_billing_group_reports/{id}:
     get:
       deprecated: false
-      description: ''
+      description: Get a ledger billing group report
       operationId: GetBillingGroupReport
       parameters:
       - description: The id of the ledger billing group report
@@ -87373,7 +87426,7 @@ paths:
       operationId: submitMdrUsageReport
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/MdrUsageRequestLegacy'
         description: MDR detail request data
@@ -87494,7 +87547,7 @@ paths:
       operationId: submitTelcoDataUsageReport
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/TelcoDataUsageRequest'
         description: Telco data usage request data
@@ -87668,7 +87721,7 @@ paths:
       operationId: submitCdrUsageReport
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/UsageRequestLegacy'
         description: Cdr detail request data
@@ -88465,6 +88518,7 @@ paths:
       x-latency-category: responsive
   /messages/group_mms:
     post:
+      description: Send a group MMS message
       operationId: CreateGroupMmsMessage
       requestBody:
         content:
@@ -88491,6 +88545,7 @@ paths:
       x-latency-category: responsive
   /messages/long_code:
     post:
+      description: Send a long code message
       operationId: CreateLongCodeMessage
       requestBody:
         content:
@@ -88517,6 +88572,7 @@ paths:
       x-latency-category: responsive
   /messages/number_pool:
     post:
+      description: Send a message using number pool
       operationId: CreateNumberPoolMessage
       requestBody:
         content:
@@ -88543,6 +88599,7 @@ paths:
       x-latency-category: responsive
   /messages/rcs:
     post:
+      description: Send an RCS message
       operationId: SendRCSMessage
       requestBody:
         content:
@@ -88642,6 +88699,7 @@ paths:
       x-latency-category: responsive
   /messages/short_code:
     post:
+      description: Send a short code message
       operationId: CreateShortCodeMessage
       requestBody:
         content:
@@ -88668,6 +88726,7 @@ paths:
       x-latency-category: responsive
   /messages/whatsapp:
     post:
+      description: Send a Whatsapp message
       operationId: SendWhatsappMessage
       requestBody:
         content:
@@ -88761,6 +88820,7 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/agents:
     get:
+      description: List all RCS agents
       operationId: ListRCSAgents
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -88779,6 +88839,7 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/agents/{id}:
     get:
+      description: Retrieve an RCS agent
       operationId: GetRCSAgentById
       parameters:
       - description: RCS agent ID
@@ -88801,6 +88862,7 @@ paths:
       - RCS
       x-latency-category: responsive
     patch:
+      description: Modify an RCS agent
       operationId: UpdateRCSAgentById
       parameters:
       - description: RCS agent ID
@@ -88829,6 +88891,7 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/bulk_capabilities:
     post:
+      description: Check RCS capabilities (batch)
       operationId: ListRCSCapabilitiesOfAPhoneNumbersBatch
       requestBody:
         content:
@@ -88850,6 +88913,7 @@ paths:
       x-latency-category: responsive
   /messaging/rcs/capabilities/{agent_id}/{phone_number}:
     get:
+      description: Check RCS capabilities
       operationId: ListRCSCapabilitiesOfAPhoneNumber
       parameters:
       - description: RCS agent ID
@@ -88909,6 +88973,7 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders:
     get:
+      description: List messaging hosted number orders
       operationId: ListMessagingHostedNumberOrders
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -88936,6 +89001,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
+      description: Create a messaging hosted number order
       operationId: CreateMessagingHostedNumberOrder
       requestBody:
         content:
@@ -88963,6 +89029,7 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders/eligibility_numbers_check:
     post:
+      description: Check hosted messaging eligibility
       operationId: CheckEligibilityNumbers
       requestBody:
         content:
@@ -89025,6 +89092,7 @@ paths:
       - Hosted Numbers
       x-latency-category: responsive
     get:
+      description: Retrieve a messaging hosted number order
       operationId: GetMessagingHostedNumberOrder
       parameters:
       - description: Identifies the type of resource.
@@ -89053,6 +89121,7 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_number_orders/{id}/actions/file_upload:
     post:
+      description: Upload hosted number document
       operationId: UploadMessagingHostedNumberOrderFile
       parameters:
       - description: Identifies the type of resource.
@@ -89227,6 +89296,7 @@ paths:
       x-latency-category: responsive
   /messaging_hosted_numbers/{id}:
     delete:
+      description: Delete a messaging hosted number
       operationId: DeleteMessagingHostedNumber
       parameters:
       - description: Identifies the type of resource.
@@ -89318,6 +89388,7 @@ paths:
       x-latency-category: responsive
   /messaging_numbers_bulk_updates:
     post:
+      description: Bulk update phone number profiles
       operationId: BulkUpdateMessagingSettingsOnPhoneNumbers
       requestBody:
         content:
@@ -89345,6 +89416,7 @@ paths:
       x-latency-category: responsive
   /messaging_numbers_bulk_updates/{order_id}:
     get:
+      description: Retrieve bulk update status
       operationId: GetBulkUpdateMessagingSettingsOnPhoneNumbersStatus
       parameters:
       - description: Order ID to verify bulk update status.
@@ -89478,6 +89550,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles:
     get:
+      description: List messaging profiles
       operationId: ListMessagingProfiles
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -89529,6 +89602,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
+      description: Create a messaging profile
       operationId: CreateMessagingProfile
       requestBody:
         content:
@@ -89557,6 +89631,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}:
     delete:
+      description: Delete a messaging profile
       operationId: DeleteMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89578,6 +89653,7 @@ paths:
       - Profiles
       x-latency-category: responsive
     get:
+      description: Retrieve a messaging profile
       operationId: RetrieveMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89599,6 +89675,7 @@ paths:
       - Profiles
       x-latency-category: responsive
     patch:
+      description: Update a messaging profile
       operationId: UpdateMessagingProfile
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89747,6 +89824,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}/phone_numbers:
     get:
+      description: List phone numbers associated with a messaging profile
       operationId: ListProfilePhoneNumbers
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89776,6 +89854,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{id}/short_codes:
     get:
+      description: List short codes associated with a messaging profile
       operationId: ListProfileShortCodes
       parameters:
       - $ref: '#/components/parameters/MessagingProfileId'
@@ -89805,6 +89884,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{profile_id}/autoresp_configs:
     get:
+      description: List Auto-Response Settings
       operationId: GetAutorespConfigs
       parameters:
       - description: Unique identifier of the profile.
@@ -89899,6 +89979,7 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     post:
+      description: Create auto-response setting
       operationId: CreateAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -89939,6 +90020,7 @@ paths:
       x-latency-category: responsive
   /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}:
     delete:
+      description: Delete Auto-Response Setting
       operationId: DeleteAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -89972,6 +90054,7 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     get:
+      description: Get Auto-Response Setting
       operationId: GetAutorespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -90014,6 +90097,7 @@ paths:
       - Opt-Out Management
       x-latency-category: responsive
     put:
+      description: Update Auto-Response Setting
       operationId: UpdateAutoRespConfig
       parameters:
       - description: Unique identifier of the profile.
@@ -90302,6 +90386,7 @@ paths:
       x-latency-category: responsive
   /messaging_url_domains:
     get:
+      description: List messaging URL domains
       operationId: ListMessagingUrlDomains
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -90362,6 +90447,7 @@ paths:
       x-latency-category: responsive
   /mobile_phone_numbers/messaging:
     get:
+      description: List mobile phone numbers with messaging settings
       operationId: ListMobilePhoneNumbersWithMessagingSettings
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -90390,6 +90476,7 @@ paths:
       x-latency-category: responsive
   /mobile_phone_numbers/{id}/messaging:
     get:
+      description: Retrieve a mobile phone number with messaging settings
       operationId: GetMobilePhoneNumberMessagingSettings
       parameters:
       - description: Identifies the type of resource.
@@ -91620,6 +91707,7 @@ paths:
       x-latency-category: responsive
   /number_order_phone_numbers/{id}/requirement_group:
     post:
+      description: Update requirement group for a phone number order
       operationId: updateNumberOrderPhoneNumberRequirementGroup
       parameters:
       - description: The unique identifier of the number order phone number
@@ -93043,6 +93131,7 @@ paths:
       x-latency-category: interactive
   /ota_updates:
     get:
+      description: List OTA updates
       operationId: ListOtaUpdates
       parameters:
       - $ref: '#/components/parameters/FilterOTAUpdatesConsolidated'
@@ -93303,6 +93392,7 @@ paths:
       x-latency-category: responsive
   /phone_number_blocks/jobs:
     get:
+      description: Lists the phone number blocks jobs
       operationId: ListPhoneNumberBlocksJobs
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93413,6 +93503,7 @@ paths:
       x-latency-category: background
   /phone_number_blocks/jobs/{id}:
     get:
+      description: Retrieves a phone number blocks job
       operationId: GetPhoneNumberBlocksJob
       parameters:
       - description: Identifies the Phone Number Blocks Job.
@@ -93449,6 +93540,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers:
     get:
+      description: List phone numbers
       operationId: ListPhoneNumbers
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93682,6 +93774,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/csv_downloads:
     get:
+      description: List CSV downloads
       operationId: ListCsvDownloads
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -93717,6 +93810,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
+      description: Create a CSV download
       operationId: CreateCsvDownload
       parameters:
       - description: Which format to use when generating the CSV file. The default
@@ -93847,6 +93941,7 @@ paths:
       x-latency-category: background
   /phone_numbers/csv_downloads/{id}:
     get:
+      description: Retrieve a CSV download
       operationId: GetCsvDownload
       parameters:
       - description: Identifies the CSV download.
@@ -93885,6 +93980,7 @@ paths:
       x-latency-category: background
   /phone_numbers/jobs:
     get:
+      description: Lists the phone numbers jobs
       operationId: ListPhoneNumbersJobs
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -94278,6 +94374,7 @@ paths:
       x-latency-category: background
   /phone_numbers/jobs/{id}:
     get:
+      description: Retrieve a phone numbers job
       operationId: RetrievePhoneNumbersJob
       parameters:
       - description: Identifies the Phone Numbers Job.
@@ -94329,6 +94426,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/messaging:
     get:
+      description: List phone numbers with messaging settings
       operationId: ListPhoneNumbersWithMessagingSettings
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -94580,6 +94678,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/voice:
     get:
+      description: List phone numbers with voice settings
       operationId: ListPhoneNumbersWithVoiceSettings
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -94665,6 +94764,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}:
     delete:
+      description: Delete a phone number
       operationId: DeletePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94695,6 +94795,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
+      description: Retrieve a phone number
       operationId: RetrievePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94725,6 +94826,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     patch:
+      description: Update a phone number
       operationId: UpdatePhoneNumber
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94763,6 +94865,8 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/actions/bundle_status_change:
     patch:
+      description: Change the bundle status for a phone number (set to being in a
+        bundle or remove from a bundle)
       operationId: PhoneNumberBundleStatusChange
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94801,6 +94905,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/actions/enable_emergency:
     post:
+      description: Enable emergency for a phone number
       operationId: EnablePhoneNumberEmergency
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94848,6 +94953,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/messaging:
     get:
+      description: Retrieve a phone number with messaging settings
       operationId: GetPhoneNumberMessagingSettings
       parameters:
       - description: Identifies the type of resource.
@@ -94875,6 +94981,8 @@ paths:
       - Number Settings
       x-latency-category: responsive
     patch:
+      description: Update the messaging profile and/or messaging product of a phone
+        number
       operationId: UpdatePhoneNumberMessagingSettings
       parameters:
       - description: The phone number to update.
@@ -94913,6 +95021,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers/{id}/voice:
     get:
+      description: Retrieve a phone number with voice settings
       operationId: GetPhoneNumberVoiceSettings
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -94944,6 +95053,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     patch:
+      description: Update a phone number with voice settings
       operationId: UpdatePhoneNumberVoiceSettings
       parameters:
       - $ref: '#/components/parameters/IntId'
@@ -95075,6 +95185,7 @@ paths:
       x-latency-category: responsive
   /phone_numbers_regulatory_requirements:
     get:
+      description: Retrieve regulatory requirements for a list of phone numbers
       operationId: ListRegulatoryRequirementsPhoneNumbers
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -99301,6 +99412,7 @@ paths:
       x-latency-category: responsive
   /regulatory_requirements:
     get:
+      description: Retrieve regulatory requirements
       operationId: ListRegulatoryRequirements
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -99512,7 +99624,7 @@ paths:
       operationId: SubmitUsageReport
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/MdrPostUsageReportRequest'
         description: Mdr usage report data
@@ -99969,6 +100081,7 @@ paths:
       x-latency-category: responsive
   /requirement_groups:
     get:
+      description: List requirement groups
       operationId: GetRequirementGroups
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100034,6 +100147,7 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     post:
+      description: Create a new requirement group
       operationId: CreateRequirementGroup
       requestBody:
         content:
@@ -100098,6 +100212,7 @@ paths:
       x-latency-category: responsive
   /requirement_groups/{id}:
     delete:
+      description: Delete a requirement group by ID
       operationId: DeleteRequirementGroup
       parameters:
       - description: ID of the requirement group
@@ -100128,6 +100243,7 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     get:
+      description: Get a single requirement group by ID
       operationId: GetRequirementGroup
       parameters:
       - description: ID of the requirement group to retrieve
@@ -100158,6 +100274,7 @@ paths:
       - Requirement Groups
       x-latency-category: responsive
     patch:
+      description: Update requirement values in requirement group
       operationId: UpdateRequirementGroup
       parameters:
       - description: ID of the requirement group
@@ -100213,6 +100330,7 @@ paths:
       x-latency-category: responsive
   /requirement_groups/{id}/submit_for_approval:
     post:
+      description: Submit a Requirement Group for Approval
       operationId: SubmitRequirementGroup
       parameters:
       - description: ID of the requirement group to submit
@@ -100367,7 +100485,7 @@ paths:
       x-latency-category: responsive
   /room_compositions:
     get:
-      description: ''
+      description: View a list of room compositions.
       operationId: ListRoomCompositions
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100488,6 +100606,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
+      description: View a room composition.
       operationId: ViewRoomComposition
       parameters:
       - description: The unique identifier of a room composition.
@@ -100517,7 +100636,7 @@ paths:
       x-latency-category: responsive
   /room_participants:
     get:
-      description: ''
+      description: View a list of room participants.
       operationId: ListRoomParticipants
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100628,6 +100747,7 @@ paths:
       x-latency-category: responsive
   /room_participants/{room_participant_id}:
     get:
+      description: View a room participant.
       operationId: ViewRoomParticipant
       parameters:
       - description: The unique identifier of a room participant.
@@ -100657,7 +100777,7 @@ paths:
       x-latency-category: responsive
   /room_recordings:
     delete:
-      description: ''
+      description: Delete several room recordings in a bulk.
       operationId: DeleteRoomRecordings
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100767,7 +100887,7 @@ paths:
       x-endpoint-cost: heavy
       x-latency-category: responsive
     get:
-      description: ''
+      description: View a list of room recordings.
       operationId: ListRoomRecordings
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -100898,6 +101018,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
+      description: View a room recording.
       operationId: ViewRoomRecording
       parameters:
       - description: The unique identifier of a room recording.
@@ -100927,7 +101048,7 @@ paths:
       x-latency-category: responsive
   /room_sessions:
     get:
-      description: ''
+      description: View a list of room sessions.
       operationId: ListRoomSessions
       parameters:
       - description: To decide if room participants should be included in the response.
@@ -101044,6 +101165,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}:
     get:
+      description: View a room session.
       operationId: ViewRoomSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101115,7 +101237,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/kick:
     post:
-      description: ''
+      description: Kick participants from a room session.
       operationId: KickParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101157,7 +101279,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/mute:
     post:
-      description: ''
+      description: Mute participants in room session.
       operationId: MuteParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101199,7 +101321,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/actions/unmute:
     post:
-      description: ''
+      description: Unmute participants in room session.
       operationId: UnmuteParticipantInSession
       parameters:
       - description: The unique identifier of a room session.
@@ -101241,7 +101363,7 @@ paths:
       x-latency-category: responsive
   /room_sessions/{room_session_id}/participants:
     get:
-      description: ''
+      description: View a list of room participants.
       operationId: RetrieveListRoomParticipants
       parameters:
       - description: The unique identifier of a room session.
@@ -101356,7 +101478,7 @@ paths:
       x-latency-category: responsive
   /rooms:
     get:
-      description: ''
+      description: View a list of rooms.
       operationId: ListRooms
       parameters:
       - description: To decide if room sessions should be included in the response.
@@ -101496,6 +101618,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     get:
+      description: View a room.
       operationId: ViewRoom
       parameters:
       - description: The unique identifier of a room.
@@ -101684,7 +101807,7 @@ paths:
       x-latency-category: responsive
   /rooms/{room_id}/sessions:
     get:
-      description: ''
+      description: View a list of room sessions.
       operationId: RetrieveListRoomSessions
       parameters:
       - description: The unique identifier of a room.
@@ -102018,6 +102141,7 @@ paths:
       x-latency-category: responsive
   /short_codes:
     get:
+      description: List short codes
       operationId: ListShortCodes
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -102059,6 +102183,7 @@ paths:
       x-latency-category: responsive
   /short_codes/{id}:
     get:
+      description: Retrieve a short code
       operationId: RetrieveShortCode
       parameters:
       - $ref: '#/components/parameters/ShortCodeId'
@@ -103935,7 +104060,7 @@ paths:
   /storage/migration_source_coverage:
     get:
       deprecated: false
-      description: ''
+      description: List Migration Source coverage
       operationId: ListMigrationSourceCoverage
       parameters: []
       responses:
@@ -103964,7 +104089,7 @@ paths:
   /storage/migration_sources:
     get:
       deprecated: false
-      description: ''
+      description: List all Migration Sources
       operationId: ListMigrationSources
       parameters: []
       responses:
@@ -104022,7 +104147,7 @@ paths:
   /storage/migration_sources/{id}:
     delete:
       deprecated: false
-      description: ''
+      description: Delete a Migration Source
       operationId: DeleteMigrationSource
       parameters:
       - description: Unique identifier for the data migration source.
@@ -104055,7 +104180,7 @@ paths:
       x-latency-category: responsive
     get:
       deprecated: false
-      description: ''
+      description: Get a Migration Source
       operationId: GetMigrationSource
       parameters:
       - description: Unique identifier for the data migration source.
@@ -104089,7 +104214,7 @@ paths:
   /storage/migrations:
     get:
       deprecated: false
-      description: ''
+      description: List all Migrations
       operationId: ListMigrations
       parameters: []
       responses:
@@ -104148,7 +104273,7 @@ paths:
   /storage/migrations/{id}:
     get:
       deprecated: false
-      description: ''
+      description: Get a Migration
       operationId: GetMigration
       parameters:
       - description: Unique identifier for the data migration.
@@ -104182,7 +104307,7 @@ paths:
   /storage/migrations/{id}/actions/stop:
     post:
       deprecated: false
-      description: ''
+      description: Stop a Migration
       operationId: StopMigration
       parameters:
       - description: Unique identifier for the data migration.
@@ -104280,6 +104405,7 @@ paths:
       x-latency-category: responsive
   /sub_number_orders/{id}/requirement_group:
     post:
+      description: Update requirement group for a sub number order
       operationId: updateSubNumberOrderRequirementGroup
       parameters:
       - description: The ID of the sub number order
@@ -107095,6 +107221,7 @@ paths:
       x-latency-category: responsive
   /v2/mobile_phone_numbers:
     get:
+      description: List Mobile Phone Numbers
       operationId: listMobilePhoneNumbers
       parameters:
       - description: The page number to load
@@ -107129,6 +107256,7 @@ paths:
       x-latency-category: responsive
   /v2/mobile_phone_numbers/{id}:
     get:
+      description: Retrieve a Mobile Phone Number
       operationId: retrieveMobilePhoneNumber
       parameters:
       - description: The ID of the mobile phone number
@@ -107154,6 +107282,7 @@ paths:
       - Mobile Phone Numbers
       x-latency-category: responsive
     patch:
+      description: Update a Mobile Phone Number
       operationId: updateMobilePhoneNumber
       parameters:
       - description: The ID of the mobile phone number
@@ -107186,6 +107315,7 @@ paths:
       x-latency-category: responsive
   /v2/mobile_voice_connections:
     get:
+      description: List Mobile Voice Connections
       operationId: listMobileVoiceConnections
       parameters:
       - description: The page number to load
@@ -107230,6 +107360,7 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     post:
+      description: Create a Mobile Voice Connection
       operationId: createMobileVoiceConnection
       requestBody:
         content:
@@ -107257,6 +107388,7 @@ paths:
       x-latency-category: responsive
   /v2/mobile_voice_connections/{id}:
     delete:
+      description: Delete a Mobile Voice Connection
       operationId: deleteMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107282,6 +107414,7 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     get:
+      description: Retrieve a Mobile Voice Connection
       operationId: retrieveMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107307,6 +107440,7 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     patch:
+      description: Update a Mobile Voice Connection
       operationId: updateMobileVoiceConnection
       parameters:
       - description: The ID of the mobile voice connection
@@ -107341,6 +107475,7 @@ paths:
       x-latency-category: responsive
   /v2/payment/stored_payment_transactions:
     post:
+      description: Create a stored payment transaction
       operationId: createStoredPaymentTransaction
       requestBody:
         content:
@@ -107401,6 +107536,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts:
     get:
+      description: List Whatsapp Business Accounts
       operationId: ListWabas
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -107416,6 +107552,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}:
     delete:
+      description: Delete a Whatsapp Business Account
       operationId: deleteWaba
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107429,6 +107566,7 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     get:
+      description: Get a single Whatsapp Business Account
       operationId: GetSingleWaba
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107444,6 +107582,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}/phone_numbers:
     get:
+      description: List phone numbers for a WABA
       operationId: ListWabaPhones
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107459,6 +107598,7 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     post:
+      description: Initialize Whatsapp phone number verification
       operationId: InitializeWhatsappVerification
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107479,6 +107619,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/business_accounts/{id}/settings:
     get:
+      description: Get WABA settings
       operationId: GetWabaSettings
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107493,6 +107634,7 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     patch:
+      description: Update WABA settings
       operationId: PatchWabaSettings
       parameters:
       - $ref: '#/components/parameters/WabaId'
@@ -107514,6 +107656,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/message_templates:
     get:
+      description: List Whatsapp message templates
       operationId: ListWhatsappTemplates
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -107552,6 +107695,7 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     post:
+      description: Create a Whatsapp message template
       operationId: PostWhatsappTemplate
       requestBody:
         content:
@@ -107571,7 +107715,8 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers:
     get:
-      operationId: ListPhoneNumbers
+      description: List Whatsapp phone numbers
+      operationId: ListWhatsappPhoneNumbers
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
       responses:
@@ -107586,6 +107731,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}:
     delete:
+      description: Delete a Whatsapp phone number
       operationId: DeleteWhatsappPhoneNumber
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107600,6 +107746,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/calling_settings:
     get:
+      description: Get calling settings for a phone number
       operationId: GetWhatsappCallingSettings
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107614,6 +107761,7 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     patch:
+      description: Enable or disable Whatsapp calling for a phone number
       operationId: PatchWhatsappCallingSettings
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107635,6 +107783,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/profile:
     get:
+      description: Get phone number business profile
       operationId: GetWhatsappProfile
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107649,6 +107798,7 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     patch:
+      description: Update phone number business profile
       operationId: PatchWhatsappProfile
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107670,6 +107820,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/profile/photo:
     delete:
+      description: Delete Whatsapp profile photo
       operationId: DeleteWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107683,6 +107834,7 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     get:
+      description: Get Whatsapp profile photo
       operationId: GetWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107700,6 +107852,7 @@ paths:
       - Whatsapp Phone Numbers
       x-latency-category: responsive
     post:
+      description: Upload Whatsapp profile photo
       operationId: PostWhatsappProfilePhoto
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107728,6 +107881,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/resend_verification:
     post:
+      description: Resend verification code
       operationId: ResendWhatsappVerification
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107748,6 +107902,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/phone_numbers/{phone_number}/verify:
     post:
+      description: Submit verification code for a phone number
       operationId: VerifyWhatsappPhoneNumber
       parameters:
       - $ref: '#/components/parameters/WhatsappPhoneNumber'
@@ -107768,6 +107923,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp/user_data:
     get:
+      description: Fetch Whatsapp user data
       operationId: GetWhatsappUserData
       responses:
         '200':
@@ -107780,6 +107936,7 @@ paths:
       - Whatsapp Business Accounts
       x-latency-category: responsive
     patch:
+      description: Update Whatsapp user data
       operationId: PatchWhatsappUserData
       requestBody:
         content:
@@ -107799,6 +107956,7 @@ paths:
       x-latency-category: responsive
   /v2/whatsapp_message_templates/{id}:
     delete:
+      description: Delete a Whatsapp message template
       operationId: DeleteWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -107812,6 +107970,7 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     get:
+      description: Get a Whatsapp message template by ID
       operationId: GetWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -107826,6 +107985,7 @@ paths:
       - Whatsapp Message Templates
       x-latency-category: responsive
     patch:
+      description: Update a Whatsapp message template
       operationId: PatchWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -108074,6 +108234,7 @@ paths:
       x-latency-category: responsive
   /verifications/by_phone_number/{phone_number}:
     get:
+      description: List verifications by phone number
       operationId: ListVerifications
       parameters:
       - description: The phone number associated with the verifications to retrieve.
@@ -108099,6 +108260,7 @@ paths:
       x-latency-category: responsive
   /verifications/by_phone_number/{phone_number}/actions/verify:
     post:
+      description: Verify verification code by phone number
       operationId: VerifyVerificationCodeByPhoneNumber
       parameters:
       - description: The phone number associated with the verification code being
@@ -108131,6 +108293,7 @@ paths:
       x-latency-category: responsive
   /verifications/call:
     post:
+      description: Trigger Call verification
       operationId: CreateVerificationCall
       requestBody:
         content:
@@ -108164,6 +108327,7 @@ paths:
       x-latency-category: responsive
   /verifications/flashcall:
     post:
+      description: Trigger Flash call verification
       operationId: CreateFlashcallVerification
       requestBody:
         content:
@@ -108197,6 +108361,7 @@ paths:
       x-latency-category: responsive
   /verifications/sms:
     post:
+      description: Trigger SMS verification
       operationId: CreateVerificationSms
       requestBody:
         content:
@@ -108219,6 +108384,7 @@ paths:
       x-latency-category: responsive
   /verifications/whatsapp:
     post:
+      description: Trigger WhatsApp verification
       operationId: CreateWhatsappVerification
       requestBody:
         content:
@@ -108253,6 +108419,7 @@ paths:
       x-latency-category: responsive
   /verifications/{verification_id}:
     get:
+      description: Retrieve verification
       operationId: RetrieveVerification
       parameters:
       - description: The identifier of the verification to retrieve.
@@ -108278,6 +108445,7 @@ paths:
       x-latency-category: responsive
   /verifications/{verification_id}/actions/verify:
     post:
+      description: Verify verification code by ID
       operationId: VerifyVerificationCodeById
       parameters:
       - description: The identifier of the verification to retrieve.
@@ -108423,6 +108591,7 @@ paths:
       x-latency-category: responsive
   /verified_numbers/{phone_number}:
     delete:
+      description: Delete a verified number
       operationId: DeleteVerifiedNumber
       parameters:
       - description: The phone number being deleted.
@@ -108451,6 +108620,7 @@ paths:
       - Verified Numbers
       x-latency-category: responsive
     get:
+      description: Retrieve a verified number
       operationId: GetVerifiedNumber
       parameters:
       - description: The phone number being requested.
@@ -108480,6 +108650,7 @@ paths:
       x-latency-category: responsive
   /verified_numbers/{phone_number}/actions/verify:
     post:
+      description: Submit verification code
       operationId: VerifyVerificationCode
       parameters:
       - description: The phone number being verified.
@@ -108715,6 +108886,7 @@ paths:
       x-latency-category: responsive
   /verify_profiles/{verify_profile_id}:
     delete:
+      description: Delete Verify profile
       operationId: DeleteProfile
       parameters:
       - description: The identifier of the Verify profile to delete.
@@ -108764,6 +108936,7 @@ paths:
       - Verify
       x-latency-category: responsive
     patch:
+      description: Update Verify profile
       operationId: UpdateVerifyProfile
       parameters:
       - description: The identifier of the Verify profile to update.


### PR DESCRIPTION
## Summary

PR #205 (merged 2026-06-09) fixed the spec issues that break LLM/agent function-calling tool generation. The auto-sync #206 regenerated the spec from the internal source and overwrote all of them. This PR re-applies the same reviewed fixes on top of current `master`, targeting the Ora "Function calling compatibility" gap (warning: "API spec found but couldn't validate function calling compatibility").

## Changes (spec3.json + spec3.yml, content identical)

**1. Duplicate `operationId` (1)** — tool names must be unique
- `ListPhoneNumbers` on `GET /v2/whatsapp/phone_numbers` → `ListWhatsappPhoneNumbers` (the core `GET /phone_numbers` keeps the original name)

**2. operationIds > 64 chars (28)** — OpenAI/Anthropic cap tool names at 64 chars (`^[a-zA-Z0-9_-]{1,64}$`)
- FastAPI-style auto-generated IDs on `/ai` paths (assistant versions, canary deploys, test suites, missions, clusters, integrations) renamed to the same concise CamelCase names reviewed in #205, e.g. `get_assistant_versions_public_assistants__assistant_id__versions_get` → `ListAssistantVersions`

**3. Missing operation descriptions (195)** — 169 ops had no `description`, 26 had an empty one; `summary` copied as `description` (same approach as #205)

**4. `*/*` request content-type → `application/json` (4)** — legacy/MDR usage-report POSTs

## Verification

- Semantic tree-diff of parsed before/after JSON: exactly 28 operationId changes + 195 description fills + 4 content-key renames, **zero** other differences
- 1082 operations: 0 duplicate, 0 missing, 0 over-long operationIds; every op has a description; rename collision check clean
- `spec3.yml` parses to a structure deep-equal to `spec3.json`; upstream scalar-quoting style preserved (no formatting churn)
- `npx @redocly/cli lint`: 58 errors → 57 (the duplicate-operationId error is gone; remaining problems are pre-existing on `master`, none introduced)

## ⚠️ Durability

These fixes live downstream of the generator, so **the next auto-sync will overwrite them again** (exactly what #206 did to #205). The durable fix is to land the same renames/descriptions in the internal source-of-truth so future syncs carry them. Until then, this keeps the public spec function-calling-compatible.