### PR TITLE
docs: describe filter params on email_domains and pricing, type oauth consent 200

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -25663,6 +25663,7 @@
             "name": "filter[status]",
             "in": "query",
             "required": false,
+            "description": "Filter domains by verification status: pending, verifying, verified, failed, degraded, or suspended.",
             "schema": {
               "$ref": "#/components/schemas/EmailDomainStatus"
             }
@@ -25691,6 +25692,7 @@
             "name": "filter[type]",
             "in": "query",
             "required": false,
+            "description": "Filter domains by type: custom, shared, or shared_inbound.",
             "schema": {
               "$ref": "#/components/schemas/EmailDomainType"
             }
@@ -25699,6 +25701,7 @@
             "name": "filter[usable_for_sending]",
             "in": "query",
             "required": false,
+            "description": "Filter domains by whether they can currently be used to send email.",
             "schema": {
               "type": "boolean"
             }
@@ -25707,6 +25710,7 @@
             "name": "filter[usable_for_inbound]",
             "in": "query",
             "required": false,
+            "description": "Filter domains by whether they can currently receive inbound email.",
             "schema": {
               "type": "boolean"
             }
@@ -48739,7 +48743,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Consent page displayed (when consent UI is embedded)"
+            "description": "Consent page displayed (when consent UI is embedded)",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "302": {
             "description": "Redirect to consent page or client with authorization code/error"
@@ -58337,6 +58348,7 @@
             "name": "filter[country_iso]",
             "in": "query",
             "required": false,
+            "description": "Two-letter ISO 3166-1 alpha-2 country code (uppercase, e.g. US) to filter pricing to a single country.",
             "schema": {
               "anyOf": [
                 {

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -103413,7 +103413,8 @@ paths:
           - domain
           - -domain
           type: string
-      - in: query
+      - description: 'Filter domains by verification status: pending, verifying, verified, failed, degraded, or suspended.'
+        in: query
         name: filter[status]
         required: false
         schema:
@@ -103432,17 +103433,20 @@ paths:
         schema:
           format: uuid
           type: string
-      - in: query
+      - description: 'Filter domains by type: custom, shared, or shared_inbound.'
+        in: query
         name: filter[type]
         required: false
         schema:
           $ref: '#/components/schemas/EmailDomainType'
-      - in: query
+      - description: Filter domains by whether they can currently be used to send email.
+        in: query
         name: filter[usable_for_sending]
         required: false
         schema:
           type: boolean
-      - in: query
+      - description: Filter domains by whether they can currently receive inbound email.
+        in: query
         name: filter[usable_for_inbound]
         required: false
         schema:
@@ -119443,6 +119447,10 @@ paths:
           type: string
       responses:
         '200':
+          content:
+            text/html:
+              schema:
+                type: string
           description: Consent page displayed (when consent UI is embedded)
         '302':
           description: Redirect to consent page or client with authorization code/error
@@ -126102,7 +126110,8 @@ paths:
           minimum: 1
           title: Page Size
           type: integer
-      - in: query
+      - description: Two-letter ISO 3166-1 alpha-2 country code (uppercase, e.g. US) to filter pricing to a single country.
+        in: query
         name: filter[country_iso]
         required: false
         schema:


### PR DESCRIPTION
## Summary

Closes the last genuinely-undocumented items surfaced by the Ora agent-readiness usability scan (`api-schema-analysis`: "1344 operations but partially documented"):

- **GET /email_domains** — adds descriptions to `filter[status]`, `filter[type]`, `filter[usable_for_sending]`, `filter[usable_for_inbound]` (the only four undescribed params in the spec besides pricing below; wording derived from the `EmailDomainStatus`/`EmailDomainType` enums).
- **GET /pricing/products/{slug}** — describes `filter[country_iso]` (ISO 3166-1 alpha-2).
- **GET /oauth/authorize** — types the 200 (consent page) as `text/html` with a string schema, matching the operation's existing 400/404/422 responses.

Applied identically to `spec3.json` and `spec3.yml`.

## Verification

- Edited nodes canonically equal between JSON and YAML after edit
- `swagger-parser` full validation passes
- `redocly lint`: 268 errors / 229 warnings — byte-for-byte the same counts as `master` (all preexisting; zero new problems)

## Durability caveat

These files are regenerated by the openapi-internal auto-sync, so this fix will be **overwritten on the next sync** unless the same changes land in the internal source specs (email, pricing, and oauth specs under `prod/external/`). This PR gets the improvement live on `telnyx.com/openapi.json` (served from this repo's master, 5-min cache) while the upstream edit follows.

## Deliberately NOT changed

18 operations declare bodyless 200/201/202 responses (11 AI/inference deletes + insight assign/unassign + conversation message, toll-free verification delete, legacy number-lookup report deletes, 10dlc 2FA email resend, STT/TTS WebSocket upgrade responses). The service-generated source mirror confirms these genuinely return no body — inventing response schemas here would misdocument the API. Typing those needs service-owner confirmation of the actual response shapes (or switching truly-empty responses to 204 at the service level).