### PR TITLE
docs: enrich all thin operation descriptions and document 202 polling patterns

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -31240,7 +31240,7 @@
         },
         "responses": {
           "202": {
-            "description": "Batch validation job accepted.",
+            "description": "Batch validation job accepted. Poll GET /email_validations/batch/{id} with the returned batch id to retrieve results.",
             "content": {
               "application/json": {
                 "schema": {
@@ -33528,7 +33528,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Upload request accepted. Track progress via GET /external_connections/{id}/uploads/status, or per ticket via GET /external_connections/{id}/uploads/{ticket_id}.",
             "content": {
               "application/json": {
                 "schema": {
@@ -33736,7 +33736,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Retry accepted. Track the upload via GET /external_connections/{id}/uploads/{ticket_id}.",
             "content": {
               "application/json": {
                 "schema": {
@@ -34198,7 +34198,7 @@
         },
         "responses": {
           "202": {
-            "description": "Send fax response",
+            "description": "Fax queued for sending. Track its progress by polling GET /faxes/{id} with the returned fax id.",
             "content": {
               "application/json": {
                 "schema": {
@@ -35286,7 +35286,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Assignment request accepted. Provisioning is asynchronous; poll GET /global_ip_assignments/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -35715,7 +35715,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /global_ip_health_checks/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -36059,7 +36059,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /global_ips/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -51303,7 +51303,7 @@
         },
         "responses": {
           "202": {
-            "description": "Phone number blocks job delete phone numbers requested.",
+            "description": "Block deletion job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -52133,7 +52133,7 @@
         },
         "responses": {
           "202": {
-            "description": "Phone numbers job delete phone numbers requested.",
+            "description": "Deletion job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -52214,7 +52214,7 @@
         },
         "responses": {
           "202": {
-            "description": "Phone numbers enable emergency requested.",
+            "description": "Emergency settings job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -52407,7 +52407,7 @@
         },
         "responses": {
           "202": {
-            "description": "Phone numbers job update phone numbers requested.",
+            "description": "Update job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -55244,7 +55244,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Activation request accepted. Track it via GET /porting_orders/{id}/activation_jobs/{activationJobId} using the returned activation job id.",
             "content": {
               "application/json": {
                 "schema": {
@@ -58572,7 +58572,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful Response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /private_wireless_gateways/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -59109,7 +59109,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /public_internet_gateways/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -62597,7 +62597,7 @@
         },
         "responses": {
           "202": {
-            "description": "Create room composition response.",
+            "description": "Composition request accepted. Poll GET /room_compositions/{room_composition_id} with the returned id until the composition completes.",
             "content": {
               "application/json": {
                 "schema": {
@@ -66111,7 +66111,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress."
           },
           "422": {
             "$ref": "#/components/responses/wireless_UnprocessableEntity"
@@ -66165,7 +66165,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress."
           },
           "422": {
             "$ref": "#/components/responses/wireless_UnprocessableEntity"
@@ -66248,7 +66248,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress."
           },
           "422": {
             "$ref": "#/components/responses/wireless_UnprocessableEntity"
@@ -66484,7 +66484,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "401": {
             "description": "Unauthorized"
@@ -66523,7 +66523,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "422": {
             "content": {
@@ -66588,7 +66588,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "422": {
             "$ref": "#/components/responses/wireless_UnprocessableEntity"
@@ -66643,7 +66643,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "400": {
             "description": "Bad Request \u2014 invalid connection_id format",
@@ -66754,7 +66754,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "401": {
             "description": "Unauthorized"
@@ -66803,7 +66803,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "401": {
             "description": "Unauthorized"
@@ -66842,7 +66842,7 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress."
           },
           "401": {
             "description": "Unauthorized"
@@ -70249,7 +70249,7 @@
         },
         "responses": {
           "202": {
-            "description": "Sub number orders report response",
+            "description": "Report generation accepted. Poll GET /sub_number_orders/report/{report_id} with the returned report id until the report is ready.",
             "content": {
               "application/json": {
                 "schema": {
@@ -70674,7 +70674,7 @@
         },
         "responses": {
           "202": {
-            "description": "Sub number orders report response",
+            "description": "Report generation accepted. Poll GET /sub_number_orders_report/{report_id} with the returned report id until the report is ready.",
             "content": {
               "application/json": {
                 "schema": {
@@ -81255,7 +81255,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /wireguard_interfaces/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -81436,7 +81436,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /wireguard_peers/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -82208,7 +82208,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful Response",
+            "description": "Creation request accepted. Provisioning is asynchronous; poll GET /wireless_blocklists/{id} with the returned id to check status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -82374,7 +82374,7 @@
         },
         "responses": {
           "202": {
-            "description": "Successful response",
+            "description": "Update accepted and processed asynchronously. Poll GET /wireless_blocklists/{id} to check the result.",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -11897,7 +11897,7 @@
           "Missions"
         ],
         "summary": "List missions",
-        "description": "List all missions for the organization",
+        "description": "Returns a paginated list of all mission definitions in your organization. Missions describe a goal and the tools, knowledge bases, and MCP servers agents may use to accomplish it.",
         "operationId": "get_public_missions_missions",
         "parameters": [
           {
@@ -11977,7 +11977,7 @@
           "Missions"
         ],
         "summary": "Create mission",
-        "description": "Create a new mission definition",
+        "description": "Creates a new mission definition from the provided configuration and returns the created mission. Execute the mission by starting runs against it.",
         "operationId": "post_public_missions_missions",
         "requestBody": {
           "required": true,
@@ -12039,7 +12039,7 @@
           "Missions"
         ],
         "summary": "List recent events",
-        "description": "List recent events across all missions",
+        "description": "Returns a paginated list of recent events across every mission in your organization, optionally filtered by event type. Useful for building activity feeds or monitoring dashboards.",
         "operationId": "get_public_missions_missions_events",
         "parameters": [
           {
@@ -12131,7 +12131,7 @@
           "Missions"
         ],
         "summary": "List recent runs",
-        "description": "List recent runs across all missions",
+        "description": "Returns a paginated list of recent runs across every mission in your organization, optionally filtered by run status. Useful for monitoring overall mission activity without querying each mission individually.",
         "operationId": "get_public_missions_missions_runs",
         "parameters": [
           {
@@ -12220,7 +12220,7 @@
           "Missions"
         ],
         "summary": "Delete mission",
-        "description": "Delete a mission",
+        "description": "Permanently deletes the specified mission definition and returns no content on success.",
         "operationId": "delete_public_missions_missions_mission_id",
         "parameters": [
           {
@@ -12324,7 +12324,7 @@
           "Missions"
         ],
         "summary": "Update mission",
-        "description": "Update a mission definition",
+        "description": "Replaces the specified mission's definition with the provided configuration and returns the updated mission.",
         "operationId": "put_public_missions_missions_mission_id",
         "parameters": [
           {
@@ -12399,7 +12399,7 @@
           "Missions"
         ],
         "summary": "Clone mission",
-        "description": "Clone an existing mission",
+        "description": "Creates a copy of the specified mission as a new mission definition, so you can iterate on its configuration without modifying the original.",
         "operationId": "post_public_missions_missions_mission_id_clone",
         "parameters": [
           {
@@ -12443,7 +12443,7 @@
           "Missions"
         ],
         "summary": "List knowledge bases",
-        "description": "List all knowledge bases for a mission",
+        "description": "Returns the knowledge bases attached to the specified mission. Knowledge bases provide reference content agents can draw on during runs.",
         "operationId": "get_public_missions_missions_mission_id_knowledge_bases",
         "parameters": [
           {
@@ -12529,7 +12529,7 @@
           "Missions"
         ],
         "summary": "Delete knowledge base",
-        "description": "Delete a knowledge base from a mission",
+        "description": "Detaches the specified knowledge base from the mission so its content is no longer available to agents in subsequent runs.",
         "operationId": "delete_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id",
         "parameters": [
           {
@@ -12586,7 +12586,7 @@
           "Missions"
         ],
         "summary": "Get knowledge base",
-        "description": "Get a specific knowledge base by ID",
+        "description": "Returns the details of a single knowledge base attached to the specified mission.",
         "operationId": "get_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id",
         "parameters": [
           {
@@ -12638,7 +12638,7 @@
           "Missions"
         ],
         "summary": "Update knowledge base",
-        "description": "Update a knowledge base definition",
+        "description": "Replaces the definition of the specified knowledge base on this mission.",
         "operationId": "put_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id",
         "parameters": [
           {
@@ -12692,7 +12692,7 @@
           "Missions"
         ],
         "summary": "List MCP servers",
-        "description": "List all MCP servers for a mission",
+        "description": "Returns the MCP servers configured on the specified mission. MCP servers expose external tools and data sources agents can use during runs.",
         "operationId": "get_public_missions_missions_mission_id_mcp_servers",
         "parameters": [
           {
@@ -12734,7 +12734,7 @@
           "Missions"
         ],
         "summary": "Create MCP server",
-        "description": "Create a new MCP server for a mission",
+        "description": "Adds an MCP server to the specified mission, making the server's tools available to agents during runs of this mission.",
         "operationId": "post_public_missions_missions_mission_id_mcp_servers",
         "parameters": [
           {
@@ -12778,7 +12778,7 @@
           "Missions"
         ],
         "summary": "Delete MCP server",
-        "description": "Delete an MCP server from a mission",
+        "description": "Removes the specified MCP server from the mission, revoking agent access to its tools in subsequent runs.",
         "operationId": "delete_public_missions_missions_mission_id_mcp_servers_mcp_server_id",
         "parameters": [
           {
@@ -12835,7 +12835,7 @@
           "Missions"
         ],
         "summary": "Get MCP server",
-        "description": "Get a specific MCP server by ID",
+        "description": "Returns the configuration of a single MCP server attached to the specified mission.",
         "operationId": "get_public_missions_missions_mission_id_mcp_servers_mcp_server_id",
         "parameters": [
           {
@@ -12887,7 +12887,7 @@
           "Missions"
         ],
         "summary": "Update MCP server",
-        "description": "Update an MCP server definition",
+        "description": "Replaces the configuration of the specified MCP server on this mission.",
         "operationId": "put_public_missions_missions_mission_id_mcp_servers_mcp_server_id",
         "parameters": [
           {
@@ -12941,7 +12941,7 @@
           "Missions"
         ],
         "summary": "List runs for mission",
-        "description": "List all runs for a specific mission",
+        "description": "Returns a paginated list of runs for the specified mission, optionally filtered by run status, so you can track the mission's execution history over time.",
         "operationId": "get_public_missions_missions_mission_id_runs",
         "parameters": [
           {
@@ -13039,7 +13039,7 @@
           "Missions"
         ],
         "summary": "Start a run",
-        "description": "Start a new run for a mission",
+        "description": "Starts a new run of the specified mission and returns the created run object. Track its progress through the run detail, plan, and events endpoints.",
         "operationId": "post_public_missions_missions_mission_id_runs",
         "parameters": [
           {
@@ -13112,7 +13112,7 @@
           "Missions"
         ],
         "summary": "Get run details",
-        "description": "Get details of a specific run",
+        "description": "Returns the full details of a single run, including its current status. Use this to poll an in-flight run or inspect the outcome of a completed one.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id",
         "parameters": [
           {
@@ -13176,7 +13176,7 @@
           "Missions"
         ],
         "summary": "Update run",
-        "description": "Update run status and/or result",
+        "description": "Updates a run's status and/or result and returns the updated run object. Typically used by executing agents to report progress or record the final outcome.",
         "operationId": "patch_public_missions_missions_mission_id_runs_run_id",
         "parameters": [
           {
@@ -13258,7 +13258,7 @@
           "Missions"
         ],
         "summary": "Cancel run",
-        "description": "Cancel a running or paused run",
+        "description": "Cancels a running or paused run and returns the updated run object. A cancelled run stops executing; start a new run to execute the mission again.",
         "operationId": "post_public_missions_missions_mission_id_runs_run_id_cancel",
         "parameters": [
           {
@@ -13326,7 +13326,7 @@
           "Missions"
         ],
         "summary": "List events",
-        "description": "List events for a run (paginated)",
+        "description": "Returns a paginated list of events logged for the specified run, filterable by event type, plan step, and agent, so you can reconstruct exactly what happened during execution.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id_events",
         "parameters": [
           {
@@ -13458,7 +13458,7 @@
           "Missions"
         ],
         "summary": "Log event",
-        "description": "Log an event for a run",
+        "description": "Logs a new event against the specified run and returns the created event. Events form the run's audit trail and can reference a plan step or agent.",
         "operationId": "post_public_missions_missions_mission_id_runs_run_id_events",
         "parameters": [
           {
@@ -13544,7 +13544,7 @@
           "Missions"
         ],
         "summary": "Get event details",
-        "description": "Get details of a specific event",
+        "description": "Returns the details of a single event logged for the specified run, including its type and payload.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id_events_event_id",
         "parameters": [
           {
@@ -13623,7 +13623,7 @@
           "Missions"
         ],
         "summary": "Pause run",
-        "description": "Pause a running run",
+        "description": "Pauses a currently running run and returns the updated run object. Execution halts until the run is resumed.",
         "operationId": "post_public_missions_missions_mission_id_runs_run_id_pause",
         "parameters": [
           {
@@ -13689,7 +13689,7 @@
           "Missions"
         ],
         "summary": "Get plan",
-        "description": "Get the plan (all steps) for a run",
+        "description": "Returns the plan for the specified run, including all plan steps and their statuses, so you can see how the mission was decomposed and how far execution has progressed.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id_plan",
         "parameters": [
           {
@@ -13757,7 +13757,7 @@
           "Missions"
         ],
         "summary": "Create initial plan",
-        "description": "Create the initial plan for a run",
+        "description": "Creates the initial plan for the specified run from the provided steps and returns the created plan steps. Progress is subsequently reported by updating individual steps.",
         "operationId": "post_public_missions_missions_mission_id_runs_run_id_plan",
         "parameters": [
           {
@@ -13937,7 +13937,7 @@
           "Missions"
         ],
         "summary": "Get step details",
-        "description": "Get details of a specific plan step",
+        "description": "Returns the details of a single plan step within a run's plan, including its status.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id",
         "parameters": [
           {
@@ -14013,7 +14013,7 @@
           "Missions"
         ],
         "summary": "Update step status",
-        "description": "Update the status of a plan step",
+        "description": "Updates the status of a single plan step and returns the updated step. Typically called by the executing agent as it works through the plan.",
         "operationId": "patch_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id",
         "parameters": [
           {
@@ -14104,7 +14104,7 @@
           "Missions"
         ],
         "summary": "Resume run",
-        "description": "Resume a paused run",
+        "description": "Resumes a previously paused run and returns the updated run object, letting execution continue from where it was paused.",
         "operationId": "post_public_missions_missions_mission_id_runs_run_id_resume",
         "parameters": [
           {
@@ -14170,7 +14170,7 @@
           "Missions"
         ],
         "summary": "List linked Telnyx agents",
-        "description": "List all Telnyx agents linked to a run",
+        "description": "Returns the Telnyx agents currently linked to the specified run. Linked agents participate in executing the run's plan.",
         "operationId": "get_public_missions_missions_mission_id_runs_run_id_telnyx_agents",
         "parameters": [
           {
@@ -14311,7 +14311,7 @@
           "Missions"
         ],
         "summary": "Unlink Telnyx agent",
-        "description": "Unlink a Telnyx agent from a run",
+        "description": "Unlinks the specified Telnyx agent from the run so it no longer participates in execution. The run itself and its history are unaffected.",
         "operationId": "delete_public_missions_missions_mission_id_runs_run_id_telnyx_agents_telnyx_agent_id",
         "parameters": [
           {
@@ -14382,7 +14382,7 @@
           "Missions"
         ],
         "summary": "List tools",
-        "description": "List all tools for a mission",
+        "description": "Returns the tools configured on the specified mission. Tools define the actions agents may invoke while executing the mission's runs.",
         "operationId": "get_public_missions_missions_mission_id_tools",
         "parameters": [
           {
@@ -14424,7 +14424,7 @@
           "Missions"
         ],
         "summary": "Create tool",
-        "description": "Create a new tool for a mission",
+        "description": "Adds a new tool to the specified mission, defining an action agents can invoke during runs of this mission.",
         "operationId": "post_public_missions_missions_mission_id_tools",
         "parameters": [
           {
@@ -14468,7 +14468,7 @@
           "Missions"
         ],
         "summary": "Delete tool",
-        "description": "Delete a tool from a mission",
+        "description": "Removes the specified tool from the mission so agents can no longer invoke it in subsequent runs.",
         "operationId": "delete_public_missions_missions_mission_id_tools_tool_id",
         "parameters": [
           {
@@ -14525,7 +14525,7 @@
           "Missions"
         ],
         "summary": "Get tool",
-        "description": "Get a specific tool by ID",
+        "description": "Returns the definition of a single tool configured on the specified mission.",
         "operationId": "get_public_missions_missions_mission_id_tools_tool_id",
         "parameters": [
           {
@@ -14577,7 +14577,7 @@
           "Missions"
         ],
         "summary": "Update tool",
-        "description": "Update a tool definition",
+        "description": "Replaces the definition of the specified tool on this mission.",
         "operationId": "put_public_missions_missions_mission_id_tools_tool_id",
         "parameters": [
           {
@@ -35098,7 +35098,7 @@
     "/global_ip_allowed_ports": {
       "get": {
         "summary": "List all Global IP Allowed Ports",
-        "description": "List all Global IP Allowed Ports",
+        "description": "Returns the ports allowed for Global IP traffic, for use when configuring Global IP resources.",
         "operationId": "ListGlobalIpAllowedPorts",
         "tags": [
           "Global IPs"
@@ -35226,7 +35226,7 @@
     "/global_ip_assignments": {
       "get": {
         "summary": "List all Global IP assignments",
-        "description": "List all Global IP assignments.",
+        "description": "Returns a paginated list of your Global IP assignments, the links between Global IPs and the WireGuard peers that receive their traffic.",
         "operationId": "ListGlobalIpAssignments",
         "tags": [
           "Global IPs"
@@ -35269,7 +35269,7 @@
       },
       "post": {
         "summary": "Create a Global IP assignment",
-        "description": "Create a Global IP assignment.",
+        "description": "Assigns a Global IP to a WireGuard peer so traffic destined for the IP is delivered over that peer's tunnel. Assignment is asynchronous, so the request is accepted and completes in the background.",
         "operationId": "CreateGlobalIpAssignment",
         "tags": [
           "Global IPs"
@@ -35404,7 +35404,7 @@
     "/global_ip_assignments/{id}": {
       "delete": {
         "summary": "Delete a Global IP assignment",
-        "description": "Delete a Global IP assignment.",
+        "description": "Deletes the specified Global IP assignment, detaching the Global IP from its WireGuard peer.",
         "operationId": "DeleteGlobalIpAssignment",
         "tags": [
           "Global IPs"
@@ -35441,7 +35441,7 @@
       },
       "get": {
         "summary": "Retrieve a Global IP assignment",
-        "description": "Retrieve a Global IP assignment.",
+        "description": "Returns the details of a single Global IP assignment, including the Global IP and WireGuard peer it links.",
         "operationId": "GetGlobalIpAssignment",
         "tags": [
           "Global IPs"
@@ -35478,7 +35478,7 @@
       },
       "patch": {
         "summary": "Update a Global IP assignment",
-        "description": "Update a Global IP assignment.",
+        "description": "Updates the specified Global IP assignment with the provided fields and returns the updated assignment.",
         "operationId": "UpdateGlobalIpAssignment",
         "tags": [
           "Global IPs"
@@ -35618,7 +35618,7 @@
     "/global_ip_health_check_types": {
       "get": {
         "summary": "List all Global IP Health check types",
-        "description": "List all Global IP Health check types.",
+        "description": "Returns the health check types available for Global IPs, for use when creating Global IP health checks.",
         "operationId": "ListGlobalIpHealthCheckTypes",
         "tags": [
           "Global IPs"
@@ -35655,7 +35655,7 @@
     "/global_ip_health_checks": {
       "get": {
         "summary": "List all Global IP health checks",
-        "description": "List all Global IP health checks.",
+        "description": "Returns a paginated list of the Global IP health checks configured on your account.",
         "operationId": "ListGlobalIpHealthChecks",
         "tags": [
           "Global IPs"
@@ -35698,7 +35698,7 @@
       },
       "post": {
         "summary": "Create a Global IP health check",
-        "description": "Create a Global IP health check.",
+        "description": "Creates a health check for a Global IP to monitor the health of its assignments. Creation is asynchronous, so the request is accepted and the health check becomes active once provisioning completes.",
         "operationId": "CreateGlobalIpHealthCheck",
         "tags": [
           "Global IPs"
@@ -35742,7 +35742,7 @@
     "/global_ip_health_checks/{id}": {
       "delete": {
         "summary": "Delete a Global IP health check",
-        "description": "Delete a Global IP health check.",
+        "description": "Deletes the specified Global IP health check so it no longer monitors the Global IP's assignments.",
         "operationId": "DeleteGlobalIpHealthCheck",
         "tags": [
           "Global IPs"
@@ -35779,7 +35779,7 @@
       },
       "get": {
         "summary": "Retrieve a Global IP health check",
-        "description": "Retrieve a Global IP health check.",
+        "description": "Returns the details of a single Global IP health check, including its type and configuration.",
         "operationId": "GetGlobalIpHealthCheck",
         "tags": [
           "Global IPs"
@@ -35890,7 +35890,7 @@
     "/global_ip_protocols": {
       "get": {
         "summary": "List all Global IP Protocols",
-        "description": "List all Global IP Protocols",
+        "description": "Returns the network protocols supported for Global IP traffic, for use when configuring Global IP resources.",
         "operationId": "ListGlobalIpProtocols",
         "tags": [
           "Global IPs"
@@ -35999,7 +35999,7 @@
     "/global_ips": {
       "get": {
         "summary": "List all Global IPs",
-        "description": "List all Global IPs.",
+        "description": "Returns a paginated list of the Global IPs on your account, including each IP's address and configuration.",
         "operationId": "ListGlobalIps",
         "tags": [
           "Global IPs"
@@ -36042,7 +36042,7 @@
       },
       "post": {
         "summary": "Create a Global IP",
-        "description": "Create a Global IP.",
+        "description": "Requests creation of a new Global IP, a static IP address announced from the Telnyx network. Provisioning is asynchronous, so the request is accepted and the Global IP becomes available once provisioning completes.",
         "operationId": "CreateGlobalIp",
         "tags": [
           "Global IPs"
@@ -36086,7 +36086,7 @@
     "/global_ips/{id}": {
       "delete": {
         "summary": "Delete a Global IP",
-        "description": "Delete a Global IP.",
+        "description": "Deletes the specified Global IP and releases its address back to Telnyx.",
         "operationId": "DeleteGlobalIp",
         "tags": [
           "Global IPs"
@@ -36123,7 +36123,7 @@
       },
       "get": {
         "summary": "Retrieve a Global IP",
-        "description": "Retrieve a Global IP.",
+        "description": "Returns the details of a single Global IP, including its address and current configuration.",
         "operationId": "GetGlobalIp",
         "tags": [
           "Global IPs"
@@ -53878,7 +53878,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Returns a list of all porting events.",
+        "description": "Returns a paginated list of porting-related events on your account, such as status changes on porting orders. Supports filtering and is useful for auditing or reconciling webhook deliveries.",
         "operationId": "listPortingEvents",
         "parameters": [
           {
@@ -53973,7 +53973,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Show a specific porting event.",
+        "description": "Returns the details of a single porting event, including its type and payload.",
         "operationId": "showPortingEvent",
         "parameters": [
           {
@@ -54019,7 +54019,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Republish a specific porting event.",
+        "description": "Republishes the specified porting event, triggering re-delivery of the corresponding webhook to your account.",
         "operationId": "republishPortingEvent",
         "parameters": [
           {
@@ -54053,7 +54053,7 @@
           "Porting Orders"
         ],
         "summary": "List LOA configurations",
-        "description": "List the LOA configurations.",
+        "description": "Returns a paginated list of your LOA (Letter of Authorization) configurations. LOA configurations customize the company details and branding used on generated LOA documents.",
         "operationId": "ListLoaConfigurations",
         "parameters": [
           {
@@ -54096,7 +54096,7 @@
           "Porting Orders"
         ],
         "summary": "Create a LOA configuration",
-        "description": "Create a LOA configuration.",
+        "description": "Creates a new LOA configuration with your company details and branding for use when generating LOA documents for porting orders.",
         "operationId": "CreateLoaConfiguration",
         "requestBody": {
           "$ref": "#/components/requestBodies/CreatePortingLOAConfiguration"
@@ -54167,7 +54167,7 @@
           "Porting Orders"
         ],
         "summary": "Delete a LOA configuration",
-        "description": "Delete a specific LOA configuration.",
+        "description": "Permanently deletes the specified LOA configuration so it can no longer be used when generating LOA documents.",
         "operationId": "DeleteLoaConfiguration",
         "parameters": [
           {
@@ -54199,7 +54199,7 @@
           "Porting Orders"
         ],
         "summary": "Retrieve a LOA configuration",
-        "description": "Retrieve a specific LOA configuration.",
+        "description": "Returns the details of a single LOA (Letter of Authorization) configuration by its identifier.",
         "operationId": "GetLoaConfiguration",
         "parameters": [
           {
@@ -54243,7 +54243,7 @@
           "Porting Orders"
         ],
         "summary": "Update a LOA configuration",
-        "description": "Update a specific LOA configuration.",
+        "description": "Updates the specified LOA configuration with the provided fields and returns the updated configuration.",
         "operationId": "UpdateLoaConfiguration",
         "parameters": [
           {
@@ -54295,7 +54295,7 @@
           "Porting Orders"
         ],
         "summary": "Preview a LOA configuration",
-        "description": "Preview a specific LOA configuration.",
+        "description": "Renders a preview of the LOA document produced by this configuration so you can verify company details and branding before using it on porting orders.",
         "operationId": "PreviewLoaConfiguration",
         "parameters": [
           {
@@ -54447,7 +54447,7 @@
           "Porting Orders"
         ],
         "summary": "Retrieve a report",
-        "description": "Retrieve a specific report generated.",
+        "description": "Returns the details of a previously requested porting report, including its status and parameters.",
         "operationId": "GetPortingReport",
         "parameters": [
           {
@@ -54493,7 +54493,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "List available carriers in the UK.",
+        "description": "Returns the list of UK carriers available for porting, for use when preparing porting orders for UK numbers.",
         "operationId": "listPortingUKCarriers",
         "responses": {
           "200": {
@@ -54530,7 +54530,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Returns a list of your porting order.",
+        "description": "Returns a paginated list of your porting orders. Supports filtering and sorting, and can optionally include the phone numbers attached to each order.",
         "operationId": "ListPortingOrders",
         "parameters": [
           {
@@ -54698,7 +54698,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Creates a new porting order object.",
+        "description": "Creates a new porting order to bring phone numbers from another carrier to Telnyx. Complete the order's requirements and then confirm it to submit the port.",
         "operationId": "CreatePortingOrder",
         "requestBody": {
           "required": true,
@@ -55274,7 +55274,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Cancel a porting order",
+        "description": "Requests cancellation of the porting order and returns the updated order.",
         "operationId": "CancelPortingOrder",
         "parameters": [
           {
@@ -55394,7 +55394,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Confirm and submit your porting order.",
+        "description": "Confirms the porting order and submits it for processing. Make sure all required information and documents are attached before confirming.",
         "operationId": "ConfirmPortingOrder",
         "parameters": [
           {
@@ -55625,7 +55625,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Returns a porting activation job.",
+        "description": "Returns the details of a single activation job for the porting order, including its current status.",
         "operationId": "GetPortingOrdersActivationJob",
         "parameters": [
           {
@@ -56057,7 +56057,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Download a porting order loa template",
+        "description": "Downloads the Letter of Authorization (LOA) template document for this porting order, optionally rendered with a specific LOA configuration.",
         "operationId": "GetPortingOrderLoaTemplate",
         "parameters": [
           {
@@ -56879,7 +56879,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Creates a new phone number block.",
+        "description": "Creates a phone number block on the porting order, representing a contiguous range of phone numbers to be ported together.",
         "operationId": "createPortingPhoneNumberBlock",
         "parameters": [
           {
@@ -56928,7 +56928,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Deletes a phone number block.",
+        "description": "Deletes the specified phone number block from the porting order.",
         "operationId": "deletePortingPhoneNumberBlock",
         "parameters": [
           {
@@ -57079,7 +57079,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Creates a new phone number extension.",
+        "description": "Creates a phone number extension on the porting order, mapping extension ranges to one of the order's phone numbers.",
         "operationId": "createPortingPhoneNumberExtension",
         "parameters": [
           {
@@ -57128,7 +57128,7 @@
         "tags": [
           "Porting Orders"
         ],
-        "description": "Deletes a phone number extension.",
+        "description": "Deletes the specified phone number extension from the porting order.",
         "operationId": "deletePortingPhoneNumberExtension",
         "parameters": [
           {
@@ -57793,7 +57793,7 @@
           "Number Portout"
         ],
         "summary": "Retrieve a report",
-        "description": "Retrieve a specific report generated.",
+        "description": "Returns the details of a previously requested port-out report, including its status and parameters.",
         "operationId": "GetPortoutReport",
         "parameters": [
           {

--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -1305,7 +1305,7 @@
             "$ref": "#/components/responses/10dlc_GenericErrorResponse"
           }
         },
-        "description": "Retrieve a brand by `brandId`.",
+        "description": "Returns the details of a 10DLC brand by its brandId, including the count of campaigns associated with the brand.",
         "x-latency-category": "responsive"
       },
       "put": {
@@ -4502,7 +4502,7 @@
     },
     "/addresses": {
       "get": {
-        "description": "Returns a list of your addresses.",
+        "description": "Returns a paginated list of the addresses on your account, with support for filtering and sorting.",
         "summary": "List all addresses",
         "operationId": "FindAddresses",
         "tags": [
@@ -4555,7 +4555,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates an address.",
+        "description": "Creates a new address on your account from the provided details, for use with services that require a physical address such as emergency calling and regulatory compliance.",
         "summary": "Creates an address",
         "operationId": "CreateAddress",
         "tags": [
@@ -4643,7 +4643,7 @@
     },
     "/addresses/{id}": {
       "delete": {
-        "description": "Deletes an existing address.",
+        "description": "Permanently deletes the specified address from your account.",
         "summary": "Deletes an address",
         "operationId": "DeleteAddress",
         "tags": [
@@ -5111,7 +5111,7 @@
           "Assistants"
         ],
         "summary": "Create an assistant",
-        "description": "Create a new AI Assistant.",
+        "description": "Creates a new AI assistant from the provided configuration, including its model, instructions, and attached tools, and returns the created assistant.",
         "operationId": "create_new_assistant_public_assistants_post",
         "requestBody": {
           "required": true,
@@ -6045,7 +6045,7 @@
           "Assistants"
         ],
         "summary": "Update an assistant",
-        "description": "Update an AI Assistant's attributes.",
+        "description": "Updates the specified AI assistant's attributes and returns the updated assistant. The request can also control how the change is promoted across assistant versions.",
         "operationId": "update_assistant_public_assistants__assistant_id__post",
         "parameters": [
           {
@@ -6940,7 +6940,7 @@
           "Assistants"
         ],
         "summary": "Get a scheduled event",
-        "description": "Retrieve a scheduled event by event ID",
+        "description": "Returns the details of a single scheduled event configured for the specified assistant.",
         "operationId": "get_scheduled_event",
         "parameters": [
           {
@@ -7141,7 +7141,7 @@
             }
           }
         },
-        "description": "Remove a tag from an AI assistant.",
+        "description": "Removes the specified tag from the AI assistant and returns the assistant's updated tag list.",
         "x-latency-category": "responsive"
       }
     },
@@ -7241,7 +7241,7 @@
             }
           }
         },
-        "description": "Detach a tool from an AI assistant.",
+        "description": "Detaches the specified tool from the AI assistant so the assistant can no longer invoke it.",
         "x-latency-category": "responsive"
       },
       "put": {
@@ -7303,7 +7303,7 @@
           "Assistants"
         ],
         "summary": "Test Assistant Tool",
-        "description": "Test a webhook tool for an assistant",
+        "description": "Executes a test invocation of the specified webhook tool for the assistant and returns the outcome, so you can verify the webhook's behavior before relying on it in conversations.",
         "operationId": "test_assistant_tool_public_assistants__assistant_id__tools__tool_id__test_post",
         "parameters": [
           {
@@ -8741,7 +8741,7 @@
       },
       "post": {
         "summary": "Add a collection source",
-        "description": "Attaches a new source to a collection.",
+        "description": "Attaches a new content source to the specified collection and returns the created source. The source's content is ingested and embedded so it becomes searchable within the collection.",
         "operationId": "AddCollectionSource",
         "tags": [
           "AI Collections"
@@ -9357,7 +9357,7 @@
           "Conversations"
         ],
         "summary": "Create a conversation",
-        "description": "Create a new AI Conversation.",
+        "description": "Creates a new AI conversation, the container for messages exchanged with an assistant, and returns the created conversation.",
         "operationId": "create_new_conversation_public_conversations_post",
         "requestBody": {
           "required": true,
@@ -9507,7 +9507,7 @@
           "Conversations"
         ],
         "summary": "Get Insight Template Groups",
-        "description": "Get all insight groups",
+        "description": "Returns a paginated list of your insight template groups. Groups organize related insight templates that are applied together when analyzing conversations.",
         "operationId": "get_all_insight_groups",
         "parameters": [
           {
@@ -9595,7 +9595,7 @@
           "Conversations"
         ],
         "summary": "Create Insight Template Group",
-        "description": "Create a new insight group",
+        "description": "Creates a new insight template group for organizing related insight templates, and returns the created group.",
         "operationId": "create_insight_group",
         "requestBody": {
           "required": true,
@@ -9663,7 +9663,7 @@
           "Conversations"
         ],
         "summary": "Delete Insight Template Group",
-        "description": "Delete insight group by ID",
+        "description": "Permanently deletes the specified insight template group by its ID.",
         "operationId": "delete_insight_group_by_id",
         "parameters": [
           {
@@ -9712,7 +9712,7 @@
           "Conversations"
         ],
         "summary": "Get Insight Template Group",
-        "description": "Get insight group by ID",
+        "description": "Returns the details of a single insight template group, including the insight templates assigned to it.",
         "operationId": "get_insight_group_by_id",
         "parameters": [
           {
@@ -9777,7 +9777,7 @@
           "Conversations"
         ],
         "summary": "Update Insight Template Group",
-        "description": "Update an insight template group",
+        "description": "Updates the specified insight template group and returns the updated group.",
         "operationId": "update_insight_group_by_id",
         "parameters": [
           {
@@ -9859,7 +9859,7 @@
           "Conversations"
         ],
         "summary": "Assign Insight Template To Group",
-        "description": "Assign an insight to a group",
+        "description": "Assigns the specified insight template to the specified insight template group.",
         "operationId": "assign_insight_to_group",
         "parameters": [
           {
@@ -9922,7 +9922,7 @@
           "Conversations"
         ],
         "summary": "Unassign Insight Template From Group",
-        "description": "Remove an insight from a group",
+        "description": "Removes the specified insight template from the specified group. The insight template itself is not deleted.",
         "operationId": "unassign_insight_from_group",
         "parameters": [
           {
@@ -9985,7 +9985,7 @@
           "Conversations"
         ],
         "summary": "Get Insight Templates",
-        "description": "Get all insights",
+        "description": "Returns a paginated list of your insight templates. Insight templates define analyses that run over AI conversations to extract structured findings.",
         "operationId": "get_all_insights",
         "parameters": [
           {
@@ -10064,7 +10064,7 @@
           "Conversations"
         ],
         "summary": "Create Insight Template",
-        "description": "Create a new insight",
+        "description": "Creates a new insight template defining an analysis to run over conversations, and returns the created template.",
         "operationId": "create_insight",
         "requestBody": {
           "required": true,
@@ -10124,7 +10124,7 @@
           "Conversations"
         ],
         "summary": "Delete Insight Template",
-        "description": "Delete insight by ID",
+        "description": "Permanently deletes the specified insight template by its ID.",
         "operationId": "delete_insight_by_id",
         "parameters": [
           {
@@ -10173,7 +10173,7 @@
           "Conversations"
         ],
         "summary": "Get Insight Template",
-        "description": "Get insight by ID",
+        "description": "Returns the details of a single insight template by its ID, including its configuration.",
         "operationId": "get_insight_by_id",
         "parameters": [
           {
@@ -10229,7 +10229,7 @@
           "Conversations"
         ],
         "summary": "Update Insight Template",
-        "description": "Update an insight template",
+        "description": "Updates the specified insight template and returns the updated template.",
         "operationId": "update_insight_by_id",
         "parameters": [
           {
@@ -10791,7 +10791,7 @@
           "Embeddings"
         ],
         "summary": "List embedded buckets",
-        "description": "Get all embedding buckets for a user.",
+        "description": "Returns the list of storage buckets that have been embedded for your account, for use with similarity search.",
         "operationId": "GetEmbeddingBuckets",
         "responses": {
           "200": {
@@ -11163,7 +11163,7 @@
           "Fine Tuning"
         ],
         "summary": "Create a fine tuning job",
-        "description": "Create a new fine tuning job.",
+        "description": "Creates a new fine-tuning job that trains a model on the provided dataset, and returns the created job.",
         "operationId": "create_new_finetuningjob_public_finetuning_post",
         "requestBody": {
           "required": true,
@@ -11227,7 +11227,7 @@
           "Fine Tuning"
         ],
         "summary": "Get a fine tuning job",
-        "description": "Retrieve a fine tuning job by `job_id`.",
+        "description": "Returns the details of a single fine-tuning job by its job_id, including its current status.",
         "operationId": "get_finetuningjob_public_finetuning__job_id__get",
         "parameters": [
           {
@@ -11285,7 +11285,7 @@
           "Fine Tuning"
         ],
         "summary": "Cancel a fine tuning job",
-        "description": "Cancel a fine tuning job.",
+        "description": "Cancels the specified in-progress fine-tuning job and returns the updated job.",
         "operationId": "cancel_new_finetuningjob_public_finetuning_post",
         "parameters": [
           {
@@ -11343,7 +11343,7 @@
           "Integrations"
         ],
         "summary": "List Integrations",
-        "description": "List all available integrations.",
+        "description": "Returns the list of third-party integrations available to connect to your AI assistants and workflows.",
         "operationId": "list_integrations_public_integrations_get",
         "responses": {
           "200": {
@@ -11391,7 +11391,7 @@
           "Integrations"
         ],
         "summary": "List User Integrations",
-        "description": "List user setup integrations",
+        "description": "Returns the list of integration connections you have set up, linking your account to third-party services.",
         "operationId": "list_user_integrations_public_integrations_connections_get",
         "responses": {
           "200": {
@@ -11481,7 +11481,7 @@
           "Integrations"
         ],
         "summary": "Get User Integration connection By Id",
-        "description": "Get user setup integrations",
+        "description": "Returns the details of a single integration connection by its ID.",
         "operationId": "get_user_integration_by_id_public_integrations_connections__user_connection_id__get",
         "parameters": [
           {
@@ -11534,7 +11534,7 @@
           "Integrations"
         ],
         "summary": "List Integration By Id",
-        "description": "Retrieve integration details",
+        "description": "Returns the details of a single available integration, including its configuration details.",
         "operationId": "list_integration_by_id_public_integrations__integration_id__get",
         "parameters": [
           {
@@ -11589,7 +11589,7 @@
           "MCP Servers"
         ],
         "summary": "List MCP Servers",
-        "description": "Retrieve a list of MCP servers.",
+        "description": "Returns a paginated list of the MCP servers configured on your account, with optional filtering by type or URL.",
         "operationId": "list_mcp_servers",
         "parameters": [
           {
@@ -11676,7 +11676,7 @@
           "MCP Servers"
         ],
         "summary": "Create MCP Server",
-        "description": "Create a new MCP server.",
+        "description": "Creates a new MCP server configuration on your account and returns the created server.",
         "operationId": "create_mcp_server",
         "requestBody": {
           "required": true,
@@ -11731,7 +11731,7 @@
           "MCP Servers"
         ],
         "summary": "Delete MCP Server",
-        "description": "Delete a specific MCP server.",
+        "description": "Permanently deletes the specified MCP server configuration from your account.",
         "operationId": "delete_mcp_server",
         "parameters": [
           {
@@ -11828,7 +11828,7 @@
           "MCP Servers"
         ],
         "summary": "Update MCP Server",
-        "description": "Update an existing MCP server.",
+        "description": "Updates the specified MCP server's configuration and returns the updated server.",
         "operationId": "update_mcp_server",
         "parameters": [
           {
@@ -15294,7 +15294,7 @@
             }
           }
         },
-        "description": "Delete a custom AI tool.",
+        "description": "Permanently deletes the specified custom AI tool from your account.",
         "x-latency-category": "responsive"
       },
       "get": {
@@ -15776,7 +15776,7 @@
       "post": {
         "summary": "Creates an authentication provider",
         "deprecated": false,
-        "description": "Creates an authentication provider.",
+        "description": "Creates a new authentication provider for single sign-on, configured from the provided identity provider details, and returns the created resource.",
         "operationId": "CreateAuthenticationProvider",
         "tags": [
           "Authentication Providers"
@@ -16725,7 +16725,7 @@
           "Bundles"
         ],
         "summary": "Retrieve Bundles",
-        "description": "Get all allowed bundles.",
+        "description": "Returns a paginated list of the billing bundles available to your account, with support for filtering.",
         "operationId": "GetUserBillingBundles",
         "parameters": [
           {
@@ -16768,7 +16768,7 @@
           "Bundles"
         ],
         "summary": "Get Bundle By Id",
-        "description": "Get a single bundle by ID.",
+        "description": "Returns the details of a single billing bundle by its ID, so you can inspect its contents before purchasing a user bundle.",
         "operationId": "GetBillingBundleById",
         "parameters": [
           {
@@ -16809,7 +16809,7 @@
         ],
         "summary": "Get User Bundles",
         "operationId": "GetUserBundles",
-        "description": "Get a paginated list of user bundles.",
+        "description": "Returns a paginated list of the bundles active on your account, with support for filtering.",
         "parameters": [
           {
             "$ref": "#/components/parameters/bundle-pricing_FilterConsolidated"
@@ -16944,7 +16944,7 @@
           "User Bundles"
         ],
         "summary": "Deactivate User Bundle",
-        "description": "Deactivates a user bundle by its ID.",
+        "description": "Deactivates the specified user bundle on your account and returns the deactivated bundle.",
         "operationId": "DeactivateUserBundle",
         "parameters": [
           {
@@ -16985,7 +16985,7 @@
           "User Bundles"
         ],
         "summary": "Get User Bundle by Id",
-        "description": "Retrieves a user bundle by its ID.",
+        "description": "Returns the details of a single user bundle on your account by its ID.",
         "operationId": "GetUserBundleById",
         "parameters": [
           {
@@ -17117,7 +17117,7 @@
       },
       "post": {
         "summary": "Create a call control application",
-        "description": "Create a call control application.",
+        "description": "Creates a call control application, which defines the webhook endpoints and settings used to control calls on associated connections.",
         "operationId": "CreateCallControlApplication",
         "tags": [
           "Call Control Applications"
@@ -17160,7 +17160,7 @@
     },
     "/call_control_applications/{id}": {
       "delete": {
-        "description": "Deletes a call control application.",
+        "description": "Permanently deletes the specified call control application and its webhook configuration.",
         "summary": "Delete a call control application",
         "operationId": "DeleteCallControlApplication",
         "tags": [
@@ -17759,7 +17759,7 @@
     "/calls/{call_control_id}/actions/ai_assistant_stop": {
       "post": {
         "summary": "Stop AI Assistant",
-        "description": "Stop an AI assistant on the call.",
+        "description": "Stops the AI assistant currently engaged on the call. The call remains active and can continue with other call control commands.",
         "operationId": "CallStopAIAssistant",
         "tags": [
           "Call Commands"
@@ -17912,7 +17912,7 @@
     "/calls/{call_control_id}/actions/client_state_update": {
       "put": {
         "summary": "Update client state",
-        "description": "Updates client state",
+        "description": "Updates the client state associated with the call. Client state is an opaque value echoed back in subsequent webhooks for the call, letting you correlate events with your application's state.",
         "operationId": "UpdateClientState",
         "tags": [
           "Call Commands"
@@ -18065,7 +18065,7 @@
     "/calls/{call_control_id}/actions/enqueue": {
       "post": {
         "summary": "Enqueue call",
-        "description": "Put the call in a queue.",
+        "description": "Places the call into a queue, where it waits until it is removed or bridged to another leg. Queue behavior is configured through the request body.",
         "operationId": "EnqueueCall",
         "tags": [
           "Call Commands"
@@ -18524,7 +18524,7 @@
     "/calls/{call_control_id}/actions/leave_queue": {
       "post": {
         "summary": "Remove call from a queue",
-        "description": "Removes the call from a queue.",
+        "description": "Removes the call from the queue it is currently waiting in. The call remains active and can be directed with further call commands.",
         "operationId": "LeaveQueue",
         "tags": [
           "Call Commands"
@@ -19595,7 +19595,7 @@
     "/calls/{call_control_id}/actions/transcription_stop": {
       "post": {
         "summary": "Transcription stop",
-        "description": "Stop real-time transcription.",
+        "description": "Stops real-time transcription on the call. Transcription webhooks cease once the command takes effect; the call itself is unaffected.",
         "operationId": "StopCallTranscription",
         "tags": [
           "Call Commands"
@@ -20272,7 +20272,7 @@
     },
     "/conferences/{conference_id}/participants": {
       "get": {
-        "description": "Lists conference participants",
+        "description": "Returns a paginated list of participants in the specified conference, with support for filtering.",
         "summary": "List conference participants",
         "operationId": "ListConferenceParticipants",
         "tags": [
@@ -20358,7 +20358,7 @@
     "/conferences/{id}": {
       "get": {
         "summary": "Retrieve a conference",
-        "description": "Retrieve an existing conference",
+        "description": "Returns the details of an existing conference, including its current status.",
         "operationId": "RetrieveConference",
         "tags": [
           "Conference Commands"
@@ -20815,7 +20815,7 @@
     "/conferences/{id}/actions/record_pause": {
       "post": {
         "summary": "Conference recording pause",
-        "description": "Pause conference recording.",
+        "description": "Pauses the active recording of the specified conference. Resume it later with the record_resume action.",
         "operationId": "PauseConferenceRecording",
         "tags": [
           "Conference Commands"
@@ -20874,7 +20874,7 @@
     "/conferences/{id}/actions/record_resume": {
       "post": {
         "summary": "Conference recording resume",
-        "description": "Resume conference recording.",
+        "description": "Resumes a previously paused recording of the specified conference, continuing capture from the point it was paused.",
         "operationId": "ResumeConferenceRecording",
         "tags": [
           "Conference Commands"
@@ -21698,7 +21698,7 @@
     "/country_coverage": {
       "get": {
         "summary": "Get country coverage",
-        "description": "Get country coverage",
+        "description": "Returns Telnyx service coverage information for every country, including which number types and features are available in each.",
         "operationId": "retreiveCountryCoverage",
         "tags": [
           "Country Coverage"
@@ -21855,7 +21855,7 @@
           }
         ],
         "summary": "Get coverage for a specific country",
-        "description": "Get coverage for a specific country",
+        "description": "Returns Telnyx service coverage information for the specified country, including available number types and features.",
         "operationId": "retreiveSpecificCountryCoverage",
         "tags": [
           "Country Coverage"
@@ -21952,7 +21952,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates a credential connection.",
+        "description": "Creates a new credential-based SIP connection. Credential connections authenticate with a username and password rather than by IP address.",
         "summary": "Create a credential connection",
         "operationId": "CreateCredentialConnection",
         "tags": [
@@ -22440,7 +22440,7 @@
           "Customer Service Record"
         ],
         "summary": "List customer service records",
-        "description": "List customer service records.",
+        "description": "Returns a paginated list of your customer service record (CSR) requests, with support for filtering and sorting.",
         "operationId": "ListCustomerServiceRecords",
         "parameters": [
           {
@@ -22614,7 +22614,7 @@
           "Customer Service Record"
         ],
         "summary": "Get a customer service record",
-        "description": "Get a specific customer service record.",
+        "description": "Returns the details of a single customer service record (CSR) request, including its status and any retrieved record data.",
         "operationId": "GetCustomerServiceRecord",
         "parameters": [
           {
@@ -22912,7 +22912,7 @@
     "/dialogflow_connections/{connection_id}": {
       "delete": {
         "summary": "Delete stored Dialogflow Connection",
-        "description": "Deletes a stored Dialogflow Connection.",
+        "description": "Deletes the stored Dialogflow connection for the specified connection.",
         "operationId": "DeleteDialogflowConnection",
         "tags": [
           "Dialogflow Integration"
@@ -23004,7 +23004,7 @@
       },
       "put": {
         "summary": "Update stored Dialogflow Connection",
-        "description": "Updates a stored Dialogflow Connection.",
+        "description": "Updates the stored Dialogflow connection for the specified connection and returns the updated configuration.",
         "operationId": "UpdateDialogflowConnection",
         "tags": [
           "Dialogflow Integration"
@@ -24340,7 +24340,7 @@
       },
       "get": {
         "summary": "Retrieve a document",
-        "description": "Retrieve a document.",
+        "description": "Returns the details of a single document on your account, including its metadata.",
         "operationId": "RetrieveDocument",
         "x-latency-category": "responsive",
         "tags": [
@@ -24393,7 +24393,7 @@
       },
       "patch": {
         "summary": "Update a document",
-        "description": "Update a document.",
+        "description": "Updates the specified document's attributes and returns the updated document.",
         "operationId": "UpdateDocument",
         "x-latency-category": "responsive",
         "tags": [
@@ -24458,7 +24458,7 @@
     "/documents/{id}/download": {
       "get": {
         "summary": "Download a document",
-        "description": "Download a document.",
+        "description": "Downloads the raw file content of the specified document as originally uploaded.",
         "operationId": "DownloadDocument",
         "x-latency-category": "responsive",
         "tags": [
@@ -24651,7 +24651,7 @@
       },
       "post": {
         "summary": "Create a dynamic emergency address.",
-        "description": "Creates a dynamic emergency address.",
+        "description": "Creates a dynamic emergency address, the validated physical location used when provisioning dynamic emergency endpoints.",
         "operationId": "CreateDynamicEmergencyAddress",
         "tags": [
           "Dynamic Emergency Addresses"
@@ -24889,7 +24889,7 @@
       },
       "post": {
         "summary": "Create a dynamic emergency endpoint.",
-        "description": "Creates a dynamic emergency endpoints.",
+        "description": "Creates a dynamic emergency endpoint, associating a callback number and location with a device for emergency calling.",
         "operationId": "CreateDynamicEmergencyEndpoint",
         "tags": [
           "Dynamic Emergency Endpoints"
@@ -30168,7 +30168,7 @@
         ],
         "operationId": "UpdateEmailTemplate",
         "summary": "Update an email template",
-        "description": "Updates one or more template fields.",
+        "description": "Updates one or more fields of the specified email template and returns the updated template.",
         "parameters": [
           {
             "$ref": "#/components/parameters/TemplateId"
@@ -34298,7 +34298,7 @@
             "$ref": "#/components/responses/programmable-fax_GenericErrorResponse"
           }
         },
-        "description": "Retrieve the details of a single fax.",
+        "description": "Returns the details of a single fax, including its current status.",
         "x-latency-category": "responsive"
       }
     },
@@ -34481,7 +34481,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates a FQDN connection.",
+        "description": "Creates a new FQDN-based SIP connection. FQDN connections authenticate by your registered domain names rather than static IP addresses.",
         "summary": "Create an FQDN connection",
         "operationId": "CreateFqdnConnection",
         "tags": [
@@ -34650,7 +34650,7 @@
     },
     "/fqdn_connections/{id}": {
       "delete": {
-        "description": "Deletes an FQDN connection.",
+        "description": "Permanently deletes the specified FQDN connection from your account.",
         "summary": "Delete an FQDN connection",
         "operationId": "DeleteFqdnConnection",
         "tags": [
@@ -34889,7 +34889,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create a new FQDN object.",
+        "description": "Creates a new FQDN record and attaches it to the specified connection.",
         "summary": "Create an FQDN",
         "operationId": "CreateFqdn",
         "tags": [
@@ -34937,7 +34937,7 @@
     },
     "/fqdns/{id}": {
       "delete": {
-        "description": "Delete an FQDN.",
+        "description": "Permanently deletes the specified FQDN record from its connection.",
         "summary": "Delete an FQDN",
         "operationId": "DeleteFqdn",
         "tags": [
@@ -35025,7 +35025,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update the details of a specific FQDN.",
+        "description": "Updates the details of the specified FQDN record and returns the updated FQDN.",
         "summary": "Update an FQDN",
         "operationId": "UpdateFqdn",
         "tags": [
@@ -37112,7 +37112,7 @@
       "get": {
         "summary": "List invoices",
         "operationId": "ListInvoices",
-        "description": "Retrieve a paginated list of invoices.",
+        "description": "Returns a paginated list of your invoices, with support for sorting.",
         "parameters": [
           {
             "name": "sort",
@@ -37269,7 +37269,7 @@
     },
     "/ip_connections": {
       "get": {
-        "description": "Returns a list of your IP connections.",
+        "description": "Returns a paginated list of your IP-based SIP connections, with support for filtering and sorting.",
         "summary": "List Ip connections",
         "operationId": "ListIpConnections",
         "tags": [
@@ -37324,7 +37324,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates an IP connection.",
+        "description": "Creates a new IP-based SIP connection, which authenticates traffic by source IP address.",
         "summary": "Create an Ip connection",
         "operationId": "CreateIpConnection",
         "tags": [
@@ -37375,7 +37375,7 @@
     },
     "/ip_connections/{id}": {
       "delete": {
-        "description": "Deletes an existing IP connection.",
+        "description": "Permanently deletes the specified IP connection from your account.",
         "summary": "Delete an Ip connection",
         "operationId": "DeleteIpConnection",
         "tags": [
@@ -37630,7 +37630,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create a new IP object.",
+        "description": "Creates a new IP record for use with IP-based connections, associating an IP address with the specified connection.",
         "summary": "Create an Ip",
         "operationId": "CreateIp",
         "tags": [
@@ -37678,7 +37678,7 @@
     },
     "/ips/{id}": {
       "delete": {
-        "description": "Delete an IP.",
+        "description": "Permanently deletes the specified IP record from its connection.",
         "summary": "Delete an Ip",
         "operationId": "DeleteIp",
         "tags": [
@@ -37766,7 +37766,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update the details of a specific IP.",
+        "description": "Updates the details of the specified IP record and returns the updated IP.",
         "summary": "Update an Ip",
         "operationId": "UpdateIp",
         "tags": [
@@ -38826,7 +38826,7 @@
           "MDR Usage Reports"
         ],
         "summary": "Get an MDR usage report",
-        "description": "Fetch single MDR usage report by id.",
+        "description": "Returns a single MDR (Message Detail Record) usage report by its identifier, including its parameters and current status.",
         "operationId": "getMdrUsageReport",
         "parameters": [
           {
@@ -38926,7 +38926,7 @@
           "Telco Data Usage Reports"
         ],
         "summary": "Submit telco data usage report",
-        "description": "Submit a new telco data usage report",
+        "description": "Submits a new telco data (number lookup) usage report request. The report is generated asynchronously; retrieve it by its identifier once ready.",
         "operationId": "submitTelcoDataUsageReport",
         "requestBody": {
           "description": "Telco data usage request data",
@@ -39279,7 +39279,7 @@
           "CDR Usage Reports"
         ],
         "summary": "Get a CDR usage report",
-        "description": "Fetch single cdr usage report by id.",
+        "description": "Returns a single CDR (Call Detail Record) usage report by its identifier, including its parameters and current status.",
         "operationId": "getCdrUsageReport",
         "parameters": [
           {
@@ -39854,7 +39854,7 @@
           "MDR Usage Reports"
         ],
         "summary": "Get an MDR usage report",
-        "description": "Fetch single MDR usage report by id.",
+        "description": "Returns a single MDR (Message Detail Record) usage report by its identifier, including its parameters and current status.",
         "operationId": "getMdrUsageReport",
         "parameters": [
           {
@@ -39954,7 +39954,7 @@
           "Telco Data Usage Reports"
         ],
         "summary": "Submit telco data usage report",
-        "description": "Submit a new telco data usage report",
+        "description": "Submits a new telco data (number lookup) usage report request. The report is generated asynchronously; retrieve it by its identifier once ready.",
         "operationId": "submitTelcoDataUsageReport",
         "requestBody": {
           "description": "Telco data usage request data",
@@ -40307,7 +40307,7 @@
           "CDR Usage Reports"
         ],
         "summary": "Get a CDR usage report",
-        "description": "Fetch single cdr usage report by id.",
+        "description": "Returns a single CDR (Call Detail Record) usage report by its identifier, including its parameters and current status.",
         "operationId": "getCdrUsageReport",
         "parameters": [
           {
@@ -40676,7 +40676,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update a single managed account.",
+        "description": "Updates the specified managed account's attributes and returns the updated account.",
         "summary": "Update a managed account",
         "operationId": "UpdateManagedAccount",
         "tags": [
@@ -40910,7 +40910,7 @@
     "/media": {
       "get": {
         "summary": "List uploaded media",
-        "description": "Returns a list of stored media files.",
+        "description": "Returns a list of the media files stored on your account, with support for filtering.",
         "operationId": "ListMediaStorage",
         "tags": [
           "Media Storage API"
@@ -41025,7 +41025,7 @@
     "/media/{media_name}": {
       "delete": {
         "summary": "Deletes stored media",
-        "description": "Deletes a stored media file.",
+        "description": "Permanently deletes the specified media file from storage.",
         "operationId": "DeleteMediaStorage",
         "tags": [
           "Media Storage API"
@@ -41094,7 +41094,7 @@
       },
       "put": {
         "summary": "Update stored media",
-        "description": "Updates a stored media file.",
+        "description": "Updates the specified stored media file and returns the updated resource.",
         "operationId": "UpdateMediaStorage",
         "tags": [
           "Media Storage API"
@@ -41156,7 +41156,7 @@
     "/media/{media_name}/download": {
       "get": {
         "summary": "Download stored media",
-        "description": "Downloads a stored media file.",
+        "description": "Downloads the raw content of the specified stored media file.",
         "operationId": "DownloadMedia",
         "tags": [
           "Media Storage API"
@@ -44428,7 +44428,7 @@
     "/messaging_optouts": {
       "get": {
         "summary": "List opt-outs",
-        "description": "Retrieve a list of opt-out blocks.",
+        "description": "Returns a paginated list of opt-out blocks created when message recipients opt out. Supports filtering and optional redaction of recipient numbers.",
         "operationId": "ListOptOuts",
         "tags": [
           "Opt-Out Management"
@@ -45969,7 +45969,7 @@
           "Push Credentials"
         ],
         "summary": "List mobile push credentials",
-        "description": "List mobile push credentials",
+        "description": "Returns a paginated list of the mobile push credentials on your account, with support for filtering.",
         "operationId": "ListPushCredentials",
         "parameters": [
           {
@@ -46031,7 +46031,7 @@
           "Push Credentials"
         ],
         "summary": "Creates a new mobile push credential",
-        "description": "Creates a new mobile push credential",
+        "description": "Creates a new mobile push credential for delivering push notifications to iOS or Android apps, and returns the created credential.",
         "operationId": "CreatePushCredential",
         "parameters": [],
         "requestBody": {
@@ -46322,7 +46322,7 @@
     "/networks": {
       "get": {
         "summary": "List all Networks",
-        "description": "List all Networks.",
+        "description": "Returns a paginated list of the private networks on your account, with support for filtering.",
         "operationId": "ListNetworks",
         "tags": [
           "Networks"
@@ -46382,7 +46382,7 @@
       },
       "post": {
         "summary": "Create a Network",
-        "description": "Create a new Network.",
+        "description": "Creates a new private network, the container that links your WireGuard interfaces, gateways, and cross connects.",
         "operationId": "CreateNetwork",
         "tags": [
           "Networks"
@@ -46426,7 +46426,7 @@
     "/networks/{id}": {
       "delete": {
         "summary": "Delete a Network",
-        "description": "Delete a Network.",
+        "description": "Permanently deletes the specified network from your account.",
         "operationId": "DeleteNetwork",
         "tags": [
           "Networks"
@@ -46463,7 +46463,7 @@
       },
       "get": {
         "summary": "Retrieve a Network",
-        "description": "Retrieve a Network.",
+        "description": "Returns the details of a single network by its identifier.",
         "operationId": "GetNetwork",
         "tags": [
           "Networks"
@@ -46500,7 +46500,7 @@
       },
       "patch": {
         "summary": "Update a Network",
-        "description": "Update a Network.",
+        "description": "Updates the specified network's attributes and returns the updated network.",
         "operationId": "UpdateNetwork",
         "tags": [
           "Networks"
@@ -46549,7 +46549,7 @@
     "/networks/{id}/default_gateway": {
       "delete": {
         "summary": "Delete Default Gateway.",
-        "description": "Delete Default Gateway.",
+        "description": "Removes the default gateway from the specified network.",
         "operationId": "DeleteDefaultGateway",
         "tags": [
           "Networks"
@@ -46592,7 +46592,7 @@
       },
       "get": {
         "summary": "Get Default Gateway status.",
-        "description": "Get Default Gateway status.",
+        "description": "Returns the status of the default gateway configured on the specified network.",
         "operationId": "GetDefaultGateway",
         "tags": [
           "Networks"
@@ -46635,7 +46635,7 @@
       },
       "post": {
         "summary": "Create Default Gateway.",
-        "description": "Create Default Gateway.",
+        "description": "Creates a default gateway on the specified network, directing the network's outbound traffic through the chosen gateway.",
         "operationId": "CreateDefaultGateway",
         "tags": [
           "Networks"
@@ -46690,7 +46690,7 @@
     "/networks/{id}/network_interfaces": {
       "get": {
         "summary": "List all Interfaces for a Network.",
-        "description": "List all Interfaces for a Network.",
+        "description": "Returns a paginated list of the interfaces attached to the specified network, with support for filtering.",
         "operationId": "ListNetworkInterfaces",
         "tags": [
           "Networks"
@@ -46763,7 +46763,7 @@
     },
     "/notification_channels": {
       "get": {
-        "description": "List notification channels.",
+        "description": "Returns a paginated list of your notification channels, the destinations that receive notifications.",
         "summary": "List notification channels",
         "operationId": "ListNotificationChannels",
         "tags": [
@@ -46812,7 +46812,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create a notification channel.",
+        "description": "Creates a new notification channel defining where notifications are delivered, and returns the created channel.",
         "summary": "Create a notification channel",
         "operationId": "CreateNotificationChannels",
         "tags": [
@@ -46859,7 +46859,7 @@
     },
     "/notification_channels/{id}": {
       "delete": {
-        "description": "Delete a notification channel.",
+        "description": "Deletes the specified notification channel so notifications are no longer delivered to it.",
         "summary": "Delete a notification channel",
         "operationId": "DeleteNotificationChannel",
         "tags": [
@@ -46899,7 +46899,7 @@
         "x-latency-category": "responsive"
       },
       "get": {
-        "description": "Get a notification channel.",
+        "description": "Returns the details of a single notification channel by its identifier.",
         "summary": "Get a notification channel",
         "operationId": "GetNotificationChannel",
         "tags": [
@@ -46942,7 +46942,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update a notification channel.",
+        "description": "Updates the specified notification channel and returns the updated channel.",
         "summary": "Update a notification channel",
         "operationId": "UpdateNotificationChannel",
         "tags": [
@@ -47140,7 +47140,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create a notification profile.",
+        "description": "Creates a new notification profile, a named grouping used to organize notification settings, and returns it.",
         "summary": "Create a notification profile",
         "operationId": "CreateNotificationProfile",
         "tags": [
@@ -47187,7 +47187,7 @@
     },
     "/notification_profiles/{id}": {
       "delete": {
-        "description": "Delete a notification profile.",
+        "description": "Deletes the specified notification profile from your account.",
         "summary": "Delete a notification profile",
         "operationId": "DeleteNotificationProfile",
         "tags": [
@@ -47227,7 +47227,7 @@
         "x-latency-category": "responsive"
       },
       "get": {
-        "description": "Get a notification profile.",
+        "description": "Returns the details of a single notification profile by its identifier.",
         "operationId": "GetNotificationProfile",
         "summary": "Get a notification profile",
         "tags": [
@@ -47270,7 +47270,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update a notification profile.",
+        "description": "Updates the specified notification profile and returns the updated profile.",
         "operationId": "UpdateNotificationProfile",
         "summary": "Update a notification profile",
         "tags": [
@@ -47323,7 +47323,7 @@
     },
     "/notification_settings": {
       "get": {
-        "description": "List notification settings.",
+        "description": "Returns a paginated list of your notification settings, which map notification event types to profiles and channels.",
         "summary": "List notification settings",
         "operationId": "ListNotificationSettings",
         "tags": [
@@ -47372,7 +47372,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Add a notification setting.",
+        "description": "Adds a notification setting that enables delivery of a notification event type to a notification profile.",
         "summary": "Add a Notification Setting",
         "operationId": "CreateNotificationSetting",
         "tags": [
@@ -47433,7 +47433,7 @@
     },
     "/notification_settings/{id}": {
       "delete": {
-        "description": "Delete a notification setting.",
+        "description": "Deletes the specified notification setting, disabling that notification delivery.",
         "summary": "Delete a notification setting",
         "operationId": "DeleteNotificationSetting",
         "tags": [
@@ -47488,7 +47488,7 @@
         "x-latency-category": "responsive"
       },
       "get": {
-        "description": "Get a notification setting.",
+        "description": "Returns the details of a single notification setting by its identifier.",
         "summary": "Get a notification setting",
         "operationId": "GetNotificationSetting",
         "tags": [
@@ -47626,7 +47626,7 @@
       },
       "post": {
         "summary": "Create a number block order",
-        "description": "Creates a phone number block order.",
+        "description": "Creates an order for a block of consecutive phone numbers and returns the created order. Track fulfillment through the order's status.",
         "operationId": "CreateNumberBlockOrder",
         "tags": [
           "Phone Number Block Orders"
@@ -48043,7 +48043,7 @@
     "/number_orders": {
       "get": {
         "summary": "List number orders",
-        "description": "Get a paginated list of number orders.",
+        "description": "Returns a paginated list of your phone number orders, with support for filtering.",
         "operationId": "ListNumberOrders",
         "tags": [
           "Phone Number Orders"
@@ -48141,7 +48141,7 @@
       },
       "post": {
         "summary": "Create a number order",
-        "description": "Creates a phone number order.",
+        "description": "Creates an order to purchase the specified phone numbers and returns the created order. Track fulfillment through the order's status.",
         "operationId": "CreateNumberOrder",
         "tags": [
           "Phone Number Orders"
@@ -48196,7 +48196,7 @@
     "/number_orders/{number_order_id}": {
       "get": {
         "summary": "Retrieve a number order",
-        "description": "Get an existing phone number order.",
+        "description": "Returns the details of an existing phone number order, including its status and the numbers included.",
         "operationId": "RetrieveNumberOrder",
         "tags": [
           "Phone Number Orders"
@@ -48249,7 +48249,7 @@
       },
       "patch": {
         "summary": "Update a number order",
-        "description": "Updates a phone number order.",
+        "description": "Updates an existing phone number order, for example to satisfy regulatory requirements attached to the order, and returns the updated order.",
         "operationId": "UpdateNumberOrder",
         "tags": [
           "Phone Number Orders"
@@ -48461,7 +48461,7 @@
     "/number_reservations/{number_reservation_id}": {
       "get": {
         "summary": "Retrieve a number reservation",
-        "description": "Gets a single phone number reservation.",
+        "description": "Returns the details of a single phone number reservation, including its status and the reserved numbers.",
         "operationId": "RetrieveNumberReservation",
         "tags": [
           "Phone Number Reservations"
@@ -48949,7 +48949,7 @@
           "OAuth Clients"
         ],
         "summary": "Create OAuth client",
-        "description": "Create a new OAuth client",
+        "description": "Creates a new OAuth client on your account for authenticating third-party integrations, and returns the created client.",
         "requestBody": {
           "required": true,
           "content": {
@@ -49039,7 +49039,7 @@
           "OAuth Clients"
         ],
         "summary": "Delete OAuth client",
-        "description": "Delete an OAuth client",
+        "description": "Permanently deletes the specified OAuth client from your account.",
         "parameters": [
           {
             "name": "id",
@@ -49079,7 +49079,7 @@
           "OAuth Clients"
         ],
         "summary": "Get OAuth client",
-        "description": "Retrieve a single OAuth client by ID",
+        "description": "Returns the details of a single OAuth client on your account by its ID.",
         "parameters": [
           {
             "name": "id",
@@ -49149,7 +49149,7 @@
           "OAuth Clients"
         ],
         "summary": "Update OAuth client",
-        "description": "Update an existing OAuth client",
+        "description": "Updates the specified OAuth client's configuration and returns the updated client.",
         "parameters": [
           {
             "name": "id",
@@ -49300,7 +49300,7 @@
           "OAuth Protocol"
         ],
         "summary": "Create OAuth grant",
-        "description": "Create an OAuth authorization grant",
+        "description": "Creates an OAuth authorization grant and returns the grant response for completing the authorization flow.",
         "requestBody": {
           "required": true,
           "content": {
@@ -49350,7 +49350,7 @@
           "OAuth Grants"
         ],
         "summary": "Revoke OAuth grant",
-        "description": "Revoke an OAuth grant",
+        "description": "Revokes the specified OAuth grant, withdrawing the access previously granted to the client.",
         "parameters": [
           {
             "name": "id",
@@ -49409,7 +49409,7 @@
           "OAuth Grants"
         ],
         "summary": "Get OAuth grant",
-        "description": "Retrieve a single OAuth grant by ID",
+        "description": "Returns the details of a single OAuth grant on your account by its ID.",
         "parameters": [
           {
             "name": "id",
@@ -49919,7 +49919,7 @@
           "OAuth Clients"
         ],
         "summary": "Create OAuth client",
-        "description": "Create a new OAuth client",
+        "description": "Creates a new OAuth client on your account for authenticating third-party integrations, and returns the created client.",
         "requestBody": {
           "required": true,
           "content": {
@@ -50009,7 +50009,7 @@
           "OAuth Clients"
         ],
         "summary": "Delete OAuth client",
-        "description": "Delete an OAuth client",
+        "description": "Permanently deletes the specified OAuth client from your account.",
         "parameters": [
           {
             "name": "id",
@@ -50049,7 +50049,7 @@
           "OAuth Clients"
         ],
         "summary": "Get OAuth client",
-        "description": "Retrieve a single OAuth client by ID",
+        "description": "Returns the details of a single OAuth client on your account by its ID.",
         "parameters": [
           {
             "name": "id",
@@ -50119,7 +50119,7 @@
           "OAuth Clients"
         ],
         "summary": "Update OAuth client",
-        "description": "Update an existing OAuth client",
+        "description": "Updates the specified OAuth client's configuration and returns the updated client.",
         "parameters": [
           {
             "name": "id",
@@ -50307,7 +50307,7 @@
           "OAuth Grants"
         ],
         "summary": "Revoke OAuth grant",
-        "description": "Revoke an OAuth grant",
+        "description": "Revokes the specified OAuth grant, withdrawing the access previously granted to the client.",
         "parameters": [
           {
             "name": "id",
@@ -50366,7 +50366,7 @@
           "OAuth Grants"
         ],
         "summary": "Get OAuth grant",
-        "description": "Retrieve a single OAuth grant by ID",
+        "description": "Returns the details of a single OAuth grant on your account by its ID.",
         "parameters": [
           {
             "name": "id",
@@ -50646,7 +50646,7 @@
     },
     "/organizations/users/{id}": {
       "get": {
-        "description": "Returns a user in your organization.",
+        "description": "Returns the details of a user in your organization, optionally including the groups the user belongs to.",
         "summary": "Get organization user",
         "operationId": "GetOrganizationUser",
         "tags": [
@@ -50703,7 +50703,7 @@
     },
     "/organizations/users/{id}/actions/remove": {
       "post": {
-        "description": "Deletes a user in your organization.",
+        "description": "Removes the specified user from your organization and returns the result of the removal.",
         "summary": "Delete organization user",
         "operationId": "DeleteOrganizationUser",
         "tags": [
@@ -50896,7 +50896,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create an outbound voice profile.",
+        "description": "Creates a new outbound voice profile defining calling permissions, destinations, and limits for outbound calls, and returns the created profile.",
         "summary": "Create an outbound voice profile",
         "operationId": "CreateVoiceProfile",
         "tags": [
@@ -57429,7 +57429,7 @@
         "tags": [
           "Number Portout"
         ],
-        "description": "Returns a list of all port-out events.",
+        "description": "Returns a paginated list of port-out events on your account, such as status changes on port-out requests, with support for filtering.",
         "operationId": "listPortoutEvents",
         "parameters": [
           {
@@ -57520,7 +57520,7 @@
         "tags": [
           "Number Portout"
         ],
-        "description": "Show a specific port-out event.",
+        "description": "Returns the details of a single port-out event, including its type and payload.",
         "operationId": "showPortoutEvent",
         "parameters": [
           {
@@ -57566,7 +57566,7 @@
         "tags": [
           "Number Portout"
         ],
-        "description": "Republish a specific port-out event.",
+        "description": "Republishes the specified port-out event, triggering re-delivery of the corresponding webhook to your account.",
         "operationId": "republishPortoutEvent",
         "parameters": [
           {
@@ -57938,7 +57938,7 @@
       },
       "post": {
         "summary": "Create a comment on a portout request",
-        "description": "Creates a comment on a portout request.",
+        "description": "Creates a comment on the specified port-out request and returns the created comment.",
         "operationId": "PostPortRequestComment",
         "tags": [
           "Number Portout"
@@ -58147,7 +58147,7 @@
     "/portouts/{id}/{status}": {
       "patch": {
         "summary": "Update Status",
-        "description": "Authorize or reject portout request",
+        "description": "Updates the status of the specified port-out request, using the status path segment to authorize or reject the port-out.",
         "operationId": "UpdatePortoutStatus",
         "tags": [
           "Number Portout"
@@ -58621,7 +58621,7 @@
     "/private_wireless_gateways/{id}": {
       "delete": {
         "summary": "Delete a Private Wireless Gateway",
-        "description": "Deletes the Private Wireless Gateway.",
+        "description": "Permanently deletes the specified Private Wireless Gateway from your account.",
         "operationId": "DeleteWirelessGateway",
         "tags": [
           "Private Wireless Gateways"
@@ -59032,7 +59032,7 @@
     "/public_internet_gateways": {
       "get": {
         "summary": "List all Public Internet Gateways",
-        "description": "List all Public Internet Gateways.",
+        "description": "Returns a paginated list of the public internet gateways on your account, with support for filtering.",
         "operationId": "ListPublicInternetGateways",
         "tags": [
           "Public Internet Gateways"
@@ -59092,7 +59092,7 @@
       },
       "post": {
         "summary": "Create a Public Internet Gateway",
-        "description": "Create a new Public Internet Gateway.",
+        "description": "Requests creation of a public internet gateway on the specified network, giving the network internet egress. Creation is asynchronous, so the request is accepted and completes in the background.",
         "operationId": "CreatePublicInternetGateway",
         "tags": [
           "Public Internet Gateways"
@@ -59136,7 +59136,7 @@
     "/public_internet_gateways/{id}": {
       "delete": {
         "summary": "Delete a Public Internet Gateway",
-        "description": "Delete a Public Internet Gateway.",
+        "description": "Deletes the specified public internet gateway, removing internet egress through it.",
         "operationId": "DeletePublicInternetGateway",
         "tags": [
           "Public Internet Gateways"
@@ -59173,7 +59173,7 @@
       },
       "get": {
         "summary": "Retrieve a Public Internet Gateway",
-        "description": "Retrieve a Public Internet Gateway.",
+        "description": "Returns the details of a single public internet gateway by its identifier.",
         "operationId": "GetPublicInternetGateway",
         "tags": [
           "Public Internet Gateways"
@@ -59276,7 +59276,7 @@
       },
       "post": {
         "summary": "Create a queue",
-        "description": "Create a new call queue.",
+        "description": "Creates a new call queue with the provided configuration and returns the created queue.",
         "operationId": "CreateQueue",
         "tags": [
           "Queue Commands"
@@ -59320,7 +59320,7 @@
     "/queues/{queue_name}": {
       "delete": {
         "summary": "Delete a queue",
-        "description": "Delete an existing call queue.",
+        "description": "Permanently deletes the specified call queue from your account.",
         "operationId": "DeleteQueue",
         "tags": [
           "Queue Commands"
@@ -59351,7 +59351,7 @@
       },
       "get": {
         "summary": "Retrieve a call queue",
-        "description": "Retrieve an existing call queue",
+        "description": "Returns the details of an existing call queue, including its current configuration.",
         "operationId": "RetrieveCallQueue",
         "tags": [
           "Queue Commands"
@@ -60418,7 +60418,7 @@
     "/recordings": {
       "get": {
         "summary": "List all call recordings",
-        "description": "Returns a list of your call recordings.",
+        "description": "Returns a paginated list of your call recordings, with support for filtering to locate specific recordings.",
         "operationId": "GetRecordings",
         "tags": [
           "Call Recordings"
@@ -60623,7 +60623,7 @@
     "/recordings/{recording_id}": {
       "delete": {
         "summary": "Delete a call recording",
-        "description": "Permanently deletes a call recording.",
+        "description": "Permanently deletes the specified call recording and returns the deleted recording resource. The media is removed and can no longer be downloaded.",
         "operationId": "DeleteRecording",
         "tags": [
           "Call Recordings"
@@ -61147,7 +61147,7 @@
         "tags": [
           "MDR Usage Reports"
         ],
-        "description": "Delete messaging usage report by id",
+        "description": "Permanently deletes the specified messaging usage report by its identifier.",
         "summary": "Delete MDR Usage Report",
         "operationId": "DeleteUsageReport",
         "parameters": [
@@ -61235,7 +61235,7 @@
         "tags": [
           "MDR Detail Reports"
         ],
-        "description": "Fetch all Mdr records ",
+        "description": "Returns message detail records (MDRs) matching the provided criteria, such as date range, direction, status, and message type.",
         "summary": "Fetch all Mdr records",
         "operationId": "GetPaginatedMdrs",
         "parameters": [
@@ -61373,7 +61373,7 @@
         "tags": [
           "WDR Detail Reports"
         ],
-        "description": "Fetch all Wdr records ",
+        "description": "Returns wireless detail records (WDRs) matching the provided criteria, such as date range, SIM card, IMSI, or phone number, with pagination and sorting.",
         "summary": "Fetches all Wdr records",
         "operationId": "GetPaginatedWdrs",
         "parameters": [
@@ -62150,7 +62150,7 @@
     "/requirement_types/{id}": {
       "get": {
         "summary": "Retrieve a requirement types",
-        "description": "Retrieve a requirement type by id",
+        "description": "Returns the details of a single requirement type by its identifier, describing a kind of documentation needed for regulatory purposes.",
         "operationId": "RetrieveRequirementType",
         "x-latency-category": "responsive",
         "tags": [
@@ -62272,7 +62272,7 @@
     "/requirements/{id}": {
       "get": {
         "summary": "Retrieve a document requirement",
-        "description": "Retrieve a document requirement record",
+        "description": "Returns a single document requirement record by its identifier, describing the documentation needed for number-related actions. A specific requirement version can be requested.",
         "operationId": "RetrieveDocumentRequirements",
         "x-latency-category": "responsive",
         "tags": [
@@ -63147,7 +63147,7 @@
     "/room_recordings/{room_recording_id}": {
       "delete": {
         "summary": "Delete a room recording.",
-        "description": "Synchronously delete a Room Recording.",
+        "description": "Synchronously deletes the specified video room recording. The recording's media is removed permanently.",
         "operationId": "DeleteRoomRecording",
         "tags": [
           "Room Recordings"
@@ -63917,7 +63917,7 @@
       },
       "post": {
         "summary": "Create a room.",
-        "description": "Synchronously create a Room.",
+        "description": "Synchronously creates a new video room with the provided configuration and returns the created room.",
         "operationId": "CreateRoom",
         "tags": [
           "Rooms"
@@ -64043,7 +64043,7 @@
       },
       "patch": {
         "summary": "Update a room.",
-        "description": "Synchronously update a Room.",
+        "description": "Synchronously updates the specified video room's configuration and returns the updated room.",
         "operationId": "UpdateRoom",
         "tags": [
           "Rooms"
@@ -65488,7 +65488,7 @@
         },
         "operationId": "CreateSimCardGroup",
         "summary": "Create a SIM card group",
-        "description": "Creates a new SIM card group object",
+        "description": "Creates a new SIM card group and returns it. Groups let you apply shared settings to a set of SIM cards.",
         "x-latency-category": "responsive"
       }
     },
@@ -65527,7 +65527,7 @@
         },
         "operationId": "DeleteSimCardGroup",
         "summary": "Delete a SIM card group",
-        "description": "Permanently deletes a SIM card group",
+        "description": "Permanently deletes the specified SIM card group from your account.",
         "x-latency-category": "responsive"
       },
       "get": {
@@ -65614,7 +65614,7 @@
         },
         "operationId": "UpdateSimCardGroup",
         "summary": "Update a SIM card group",
-        "description": "Updates a SIM card group",
+        "description": "Updates the specified SIM card group's attributes and returns the updated group.",
         "x-latency-category": "responsive"
       }
     },
@@ -65819,7 +65819,7 @@
     "/sim_card_order_preview": {
       "post": {
         "summary": "Preview SIM card orders",
-        "description": "Preview SIM card order purchases.",
+        "description": "Previews a SIM card order purchase, returning estimated costs and details before you place the order. The preview is processed asynchronously.",
         "operationId": "PreviewSimCardOrders",
         "tags": [
           "SIM Card Orders"
@@ -65958,7 +65958,7 @@
           }
         },
         "summary": "Create a SIM card order",
-        "description": "Creates a new order for SIM cards.",
+        "description": "Creates a new order for physical SIM cards, including quantity and shipping details, and returns the created order.",
         "operationId": "CreateSimCardOrder",
         "x-latency-category": "responsive"
       }
@@ -65966,7 +65966,7 @@
     "/sim_card_orders/{id}": {
       "get": {
         "summary": "Get a single SIM card order",
-        "description": "Get a single SIM card order by its ID.",
+        "description": "Returns the details of a single SIM card order by its ID, including its status.",
         "operationId": "GetSimCardOrder",
         "tags": [
           "SIM Card Orders"
@@ -66410,7 +66410,7 @@
       },
       "patch": {
         "summary": "Update a SIM card",
-        "description": "Updates SIM card data",
+        "description": "Updates the specified SIM card's attributes and returns the updated SIM card.",
         "operationId": "UpdateSimCard",
         "tags": [
           "SIM Cards"
@@ -67213,7 +67213,7 @@
     "/siprec_connectors/{connector_name}": {
       "delete": {
         "summary": "Delete a SIPREC connector",
-        "description": "Deletes a stored SIPREC connector.",
+        "description": "Deletes the stored SIPREC connector with the specified connector name.",
         "operationId": "deleteSiprecConnector",
         "tags": [
           "SIPREC Connectors"
@@ -69606,7 +69606,7 @@
       "post": {
         "summary": "Stop a Migration",
         "deprecated": false,
-        "description": "Stop an in-progress storage migration.",
+        "description": "Stops the specified in-progress storage migration and returns the updated migration.",
         "operationId": "StopMigration",
         "tags": [
           "Data Migration"
@@ -70465,7 +70465,7 @@
     "/sub_number_orders/{sub_number_order_id}": {
       "get": {
         "summary": "Retrieve a sub number order",
-        "description": "Get an existing sub number order.",
+        "description": "Returns the details of an existing sub number order, with support for filtering.",
         "operationId": "GetSubNumberOrder",
         "tags": [
           "Phone Number Orders"
@@ -70535,7 +70535,7 @@
       },
       "patch": {
         "summary": "Update a sub number order's requirements",
-        "description": "Updates a sub number order.",
+        "description": "Updates the requirements of an existing sub number order and returns the updated order.",
         "operationId": "UpdateSubNumberOrder",
         "tags": [
           "Phone Number Orders"
@@ -70816,7 +70816,7 @@
     },
     "/telephony_credentials": {
       "get": {
-        "description": "List all On-demand Credentials.",
+        "description": "Returns a paginated list of the on-demand telephony credentials on your account, with support for filtering.",
         "summary": "List all credentials",
         "operationId": "FindTelephonyCredentials",
         "tags": [
@@ -70867,7 +70867,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Create a credential.",
+        "description": "Creates a new on-demand telephony credential for the specified connection. The credential can then be used to generate access tokens for SIP or WebRTC clients.",
         "summary": "Create a credential",
         "operationId": "CreateTelephonyCredential",
         "tags": [
@@ -70911,7 +70911,7 @@
     },
     "/telephony_credentials/{id}": {
       "delete": {
-        "description": "Delete an existing credential.",
+        "description": "Permanently deletes the specified telephony credential, revoking any access it provided.",
         "summary": "Delete a credential",
         "operationId": "DeleteTelephonyCredential",
         "tags": [
@@ -71005,7 +71005,7 @@
         "x-latency-category": "responsive"
       },
       "patch": {
-        "description": "Update an existing credential.",
+        "description": "Updates the specified telephony credential and returns the updated credential.",
         "summary": "Update a credential",
         "operationId": "UpdateTelephonyCredential",
         "tags": [
@@ -71791,7 +71791,7 @@
     "/texml/Accounts/{account_sid}/Conferences": {
       "get": {
         "summary": "List conference resources",
-        "description": "Lists conference resources.",
+        "description": "Returns a paginated list of conference resources for the account, with support for filtering by friendly name, status, and creation or update dates.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlConferences",
         "tags": [
@@ -71843,7 +71843,7 @@
     "/texml/Accounts/{account_sid}/Conferences/{conference_sid}": {
       "get": {
         "summary": "Fetch a conference resource",
-        "description": "Returns a conference resource.",
+        "description": "Returns a single conference resource for the account by its ConferenceSid.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlConference",
         "tags": [
@@ -71875,7 +71875,7 @@
       },
       "post": {
         "summary": "Update a conference resource",
-        "description": "Updates a conference resource.",
+        "description": "Updates the specified conference resource, for example to modify its status, and returns the updated conference.",
         "x-latency-category": "responsive",
         "operationId": "UpdateTexmlConference",
         "tags": [
@@ -71920,7 +71920,7 @@
     "/texml/Accounts/{account_sid}/Conferences/{conference_sid}/Participants": {
       "get": {
         "summary": "List conference participants",
-        "description": "Lists conference participants",
+        "description": "Returns the list of participants currently in the specified conference.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlConferenceParticipants",
         "tags": [
@@ -71952,7 +71952,7 @@
       },
       "post": {
         "summary": "Dial a new conference participant",
-        "description": "Dials a new conference participant",
+        "description": "Dials a new participant into the specified conference and returns the created participant resource.",
         "x-latency-category": "responsive",
         "operationId": "DialTexmlConferenceParticipant",
         "tags": [
@@ -71997,7 +71997,7 @@
     "/texml/Accounts/{account_sid}/Conferences/{conference_sid}/Participants/{call_sid_or_participant_label}": {
       "delete": {
         "summary": "Delete a conference participant",
-        "description": "Deletes a conference participant",
+        "description": "Removes the specified participant from the conference, ending their leg of the call.",
         "x-latency-category": "responsive",
         "operationId": "DeleteTexmlConferenceParticipant",
         "tags": [
@@ -72025,7 +72025,7 @@
       },
       "get": {
         "summary": "Get conference participant resource",
-        "description": "Gets conference participant resource",
+        "description": "Returns a single conference participant resource by call SID or participant label.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlConferenceParticipant",
         "tags": [
@@ -72060,7 +72060,7 @@
       },
       "post": {
         "summary": "Update a conference participant",
-        "description": "Updates a conference participant",
+        "description": "Updates the specified conference participant, for example muting or holding them, and returns the updated participant.",
         "x-latency-category": "responsive",
         "operationId": "UpdateTexmlConferenceParticipant",
         "tags": [
@@ -72108,7 +72108,7 @@
     "/texml/Accounts/{account_sid}/Conferences/{conference_sid}/Recordings": {
       "get": {
         "summary": "List conference recordings",
-        "description": "Lists conference recordings",
+        "description": "Returns the list of recordings made for the specified conference.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlConferenceRecordings",
         "tags": [
@@ -72177,7 +72177,7 @@
     "/texml/Accounts/{account_sid}/Queues": {
       "get": {
         "summary": "List queue resources",
-        "description": "Lists queue resources.",
+        "description": "Returns a paginated list of queue resources for the account, with support for filtering by creation or update dates.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlQueues",
         "tags": [
@@ -72221,7 +72221,7 @@
       },
       "post": {
         "summary": "Create a new queue",
-        "description": "Creates a new queue resource.",
+        "description": "Creates a new queue resource for the account with the provided settings and returns it.",
         "x-latency-category": "responsive",
         "operationId": "CreateTexmlQueue",
         "tags": [
@@ -72263,7 +72263,7 @@
     "/texml/Accounts/{account_sid}/Queues/{queue_sid}": {
       "delete": {
         "summary": "Delete a queue resource",
-        "description": "Delete a queue resource.",
+        "description": "Permanently deletes the specified queue resource from the account.",
         "x-latency-category": "responsive",
         "operationId": "DeleteTexmlQueue",
         "tags": [
@@ -72288,7 +72288,7 @@
       },
       "get": {
         "summary": "Fetch a queue resource",
-        "description": "Returns a queue resource.",
+        "description": "Returns a single queue resource for the account by its QueueSid.",
         "x-latency-category": "responsive",
         "operationId": "GetTexmlQueue",
         "tags": [
@@ -72320,7 +72320,7 @@
       },
       "post": {
         "summary": "Update a queue resource",
-        "description": "Updates a queue resource.",
+        "description": "Updates the specified queue resource's settings and returns the updated queue.",
         "x-latency-category": "responsive",
         "operationId": "UpdateTexmlQueue",
         "tags": [
@@ -72758,7 +72758,7 @@
         "x-latency-category": "interactive"
       },
       "post": {
-        "description": "Creates a TeXML Application.",
+        "description": "Creates a TeXML application, which defines the voice URLs and settings used to serve TeXML instructions for calls, and returns the created application.",
         "summary": "Creates a TeXML Application",
         "operationId": "CreateTexmlApplication",
         "tags": [
@@ -72812,7 +72812,7 @@
     },
     "/texml_applications/{id}": {
       "delete": {
-        "description": "Deletes a TeXML Application.",
+        "description": "Permanently deletes the specified TeXML application from your account.",
         "summary": "Deletes a TeXML Application",
         "operationId": "DeleteTexmlApplication",
         "tags": [
@@ -73529,7 +73529,7 @@
     "/traffic/policy/profiles/{id}": {
       "delete": {
         "summary": "Delete a traffic policy profile",
-        "description": "Deletes the traffic policy profile.",
+        "description": "Permanently deletes the specified traffic policy profile from your account.",
         "operationId": "DeleteTrafficPolicyProfile",
         "tags": [
           "Traffic Policy Profiles"
@@ -73611,7 +73611,7 @@
       },
       "patch": {
         "summary": "Update a traffic policy profile",
-        "description": "Updates a traffic policy profile.",
+        "description": "Updates the specified traffic policy profile and returns the updated profile.",
         "operationId": "UpdateTrafficPolicyProfile",
         "tags": [
           "Traffic Policy Profiles"
@@ -73972,7 +73972,7 @@
     "/traffic_policy_profiles/{id}": {
       "delete": {
         "summary": "Delete a traffic policy profile",
-        "description": "Deletes the traffic policy profile.",
+        "description": "Permanently deletes the specified traffic policy profile from your account.",
         "operationId": "DeleteTrafficPolicyProfile",
         "tags": [
           "Traffic Policy Profiles"
@@ -74054,7 +74054,7 @@
       },
       "patch": {
         "summary": "Update a traffic policy profile",
-        "description": "Updates a traffic policy profile.",
+        "description": "Updates the specified traffic policy profile and returns the updated profile.",
         "operationId": "UpdateTrafficPolicyProfile",
         "tags": [
           "Traffic Policy Profiles"
@@ -74266,7 +74266,7 @@
     },
     "/uac_connections/{id}": {
       "delete": {
-        "description": "Deletes an existing UAC connection.",
+        "description": "Permanently deletes the specified UAC connection from your account.",
         "summary": "Delete a UAC connection",
         "operationId": "DeleteUacConnection",
         "tags": [
@@ -74940,7 +74940,7 @@
     },
     "/user/addresses": {
       "get": {
-        "description": "Returns a list of your user addresses.",
+        "description": "Returns a paginated list of your user addresses, with support for filtering and sorting.",
         "summary": "List all user addresses",
         "operationId": "FindUserAddress",
         "tags": [
@@ -74993,7 +74993,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates a user address.",
+        "description": "Creates a new user address from the provided details and returns the created address.",
         "summary": "Creates a user address",
         "operationId": "CreateUserAddress",
         "tags": [
@@ -75085,7 +75085,7 @@
     },
     "/user_addresses": {
       "get": {
-        "description": "Returns a list of your user addresses.",
+        "description": "Returns a paginated list of your user addresses, with support for filtering and sorting.",
         "summary": "List all user addresses",
         "operationId": "FindUserAddress",
         "tags": [
@@ -75138,7 +75138,7 @@
         "x-latency-category": "responsive"
       },
       "post": {
-        "description": "Creates a user address.",
+        "description": "Creates a new user address from the provided details and returns the created address.",
         "summary": "Creates a user address",
         "operationId": "CreateUserAddress",
         "tags": [
@@ -75232,7 +75232,7 @@
       "get": {
         "summary": "List User Tags",
         "operationId": "GetUserTags",
-        "description": "List all user tags.",
+        "description": "Returns the user tags defined on your account, with support for filtering. Tags help organize resources such as phone numbers.",
         "tags": [
           "User Tags"
         ],
@@ -75577,7 +75577,7 @@
             "description": "Unprocessable Entity"
           }
         },
-        "description": "Create a new mobile voice connection.",
+        "description": "Creates a new mobile voice connection with the provided configuration and returns the created connection.",
         "x-latency-category": "responsive"
       }
     },
@@ -78111,7 +78111,7 @@
           "Verify"
         ],
         "summary": "Retrieve Verify profile",
-        "description": "Gets a single Verify profile.",
+        "description": "Returns the details of a single Verify profile by its ID, including its verification channel configuration.",
         "operationId": "GetVerifyProfile",
         "parameters": [
           {
@@ -78239,7 +78239,7 @@
     "/virtual_cross_connects": {
       "get": {
         "summary": "List all Virtual Cross Connects",
-        "description": "List all Virtual Cross Connects.",
+        "description": "Returns a paginated list of the virtual cross connects on your account, with support for filtering.",
         "operationId": "ListVirtualCrossConnects",
         "tags": [
           "Virtual Cross Connects"
@@ -78467,7 +78467,7 @@
     "/virtual_cross_connects/{id}": {
       "delete": {
         "summary": "Delete a Virtual Cross Connect",
-        "description": "Delete a Virtual Cross Connect.",
+        "description": "Deletes the specified virtual cross connect from your account.",
         "operationId": "DeleteVirtualCrossConnect",
         "tags": [
           "Virtual Cross Connects"
@@ -78504,7 +78504,7 @@
       },
       "get": {
         "summary": "Retrieve a Virtual Cross Connect",
-        "description": "Retrieve a Virtual Cross Connect.",
+        "description": "Returns the details of a single virtual cross connect by its identifier.",
         "operationId": "GetVirtualCrossConnect",
         "tags": [
           "Virtual Cross Connects"
@@ -80662,7 +80662,7 @@
           }
         },
         "x-latency-category": "responsive",
-        "description": "Delete a WhatsApp message template."
+        "description": "Permanently deletes the specified WhatsApp message template from your account."
       },
       "get": {
         "tags": [
@@ -81178,7 +81178,7 @@
     "/wireguard_interfaces": {
       "get": {
         "summary": "List all WireGuard Interfaces",
-        "description": "List all WireGuard Interfaces.",
+        "description": "Returns a paginated list of the WireGuard interfaces on your account, with support for filtering.",
         "operationId": "ListWireguardInterfaces",
         "tags": [
           "WireGuard Interfaces"
@@ -81282,7 +81282,7 @@
     "/wireguard_interfaces/{id}": {
       "delete": {
         "summary": "Delete a WireGuard Interface",
-        "description": "Delete a WireGuard Interface.",
+        "description": "Deletes the specified WireGuard interface from its network.",
         "operationId": "DeleteWireguardInterface",
         "tags": [
           "WireGuard Interfaces"
@@ -81319,7 +81319,7 @@
       },
       "get": {
         "summary": "Retrieve a WireGuard Interfaces",
-        "description": "Retrieve a WireGuard Interfaces.",
+        "description": "Returns the details of a single WireGuard interface by its identifier.",
         "operationId": "GetWireguardInterface",
         "tags": [
           "WireGuard Interfaces"
@@ -81358,7 +81358,7 @@
     "/wireguard_peers": {
       "get": {
         "summary": "List all WireGuard Peers",
-        "description": "List all WireGuard peers.",
+        "description": "Returns a paginated list of your WireGuard peers, with support for filtering.",
         "operationId": "ListWireguardPeers",
         "tags": [
           "WireGuard Interfaces"
@@ -81463,7 +81463,7 @@
     "/wireguard_peers/{id}": {
       "delete": {
         "summary": "Delete the WireGuard Peer",
-        "description": "Delete the WireGuard peer.",
+        "description": "Deletes the specified WireGuard peer from its interface.",
         "operationId": "DeleteWireguardPeer",
         "tags": [
           "WireGuard Interfaces"
@@ -81500,7 +81500,7 @@
       },
       "get": {
         "summary": "Retrieve the WireGuard Peer",
-        "description": "Retrieve the WireGuard peer.",
+        "description": "Returns the details of a single WireGuard peer by its identifier.",
         "operationId": "GetWireguardPeer",
         "tags": [
           "WireGuard Interfaces"
@@ -81537,7 +81537,7 @@
       },
       "patch": {
         "summary": "Update the WireGuard Peer",
-        "description": "Update the WireGuard peer.",
+        "description": "Updates the specified WireGuard peer and returns the updated peer.",
         "operationId": "UpdateWireguardPeer",
         "tags": [
           "WireGuard Interfaces"
@@ -81708,7 +81708,7 @@
     "/wireless/detail/records/reports/{id}": {
       "delete": {
         "summary": "Delete a Wireless Detail Record (WDR) Report",
-        "description": "Deletes one specific WDR report.",
+        "description": "Permanently deletes the specified Wireless Detail Record (WDR) report.",
         "operationId": "DeleteWdrReport",
         "tags": [
           "Reporting"
@@ -81746,7 +81746,7 @@
       "get": {
         "x-latency-category": "background",
         "summary": "Get a Wireless Detail Record (WDR) Report",
-        "description": "Returns one specific WDR report",
+        "description": "Returns a single Wireless Detail Record (WDR) report by its identifier, including its parameters and current status.",
         "operationId": "GetWdrReport",
         "tags": [
           "Reporting"
@@ -81871,7 +81871,7 @@
     "/wireless/detail_records_reports/{id}": {
       "delete": {
         "summary": "Delete a Wireless Detail Record (WDR) Report",
-        "description": "Deletes one specific WDR report.",
+        "description": "Permanently deletes the specified Wireless Detail Record (WDR) report.",
         "operationId": "DeleteWdrReport",
         "tags": [
           "Reporting"
@@ -81909,7 +81909,7 @@
       "get": {
         "x-latency-category": "background",
         "summary": "Get a Wireless Detail Record (WDR) Report",
-        "description": "Returns one specific WDR report",
+        "description": "Returns a single Wireless Detail Record (WDR) report by its identifier, including its parameters and current status.",
         "operationId": "GetWdrReport",
         "tags": [
           "Reporting"
@@ -82250,7 +82250,7 @@
     "/wireless_blocklists/{id}": {
       "delete": {
         "summary": "Delete a Wireless Blocklist",
-        "description": "Deletes the Wireless Blocklist.",
+        "description": "Permanently deletes the specified wireless blocklist from your account.",
         "operationId": "DeleteWirelessBlocklist",
         "tags": [
           "Wireless Blocklists"
@@ -82324,7 +82324,7 @@
       },
       "patch": {
         "summary": "Update a Wireless Blocklist",
-        "description": "Update a Wireless Blocklist.",
+        "description": "Updates the specified wireless blocklist. The update is processed asynchronously, so the request is accepted and completes in the background.",
         "operationId": "UpdateWirelessBlocklist",
         "tags": [
           "Wireless Blocklists"

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -86068,7 +86068,7 @@ paths:
       - Brands
       x-latency-category: responsive
     get:
-      description: Retrieve a brand by `brandId`.
+      description: Returns the details of a 10DLC brand by its brandId, including the count of campaigns associated with the brand.
       operationId: GetBrand
       parameters:
       - description: Unique identifier of the brand.
@@ -88396,7 +88396,7 @@ paths:
       x-latency-category: background
   /addresses:
     get:
-      description: Returns a list of your addresses.
+      description: Returns a paginated list of the addresses on your account, with support for filtering and sorting.
       operationId: FindAddresses
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -88428,7 +88428,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     post:
-      description: Creates an address.
+      description: Creates a new address on your account from the provided details, for use with services that require a physical address such as emergency calling and regulatory compliance.
       operationId: CreateAddress
       parameters: []
       requestBody:
@@ -88486,7 +88486,7 @@ paths:
       x-latency-category: responsive
   /addresses/{id}:
     delete:
-      description: Deletes an existing address.
+      description: Permanently deletes the specified address from your account.
       operationId: DeleteAddress
       parameters:
       - description: address ID
@@ -88811,7 +88811,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     post:
-      description: Create a new AI Assistant.
+      description: Creates a new AI assistant from the provided configuration, including its model, instructions, and attached tools, and returns the created assistant.
       operationId: create_new_assistant_public_assistants_post
       requestBody:
         content:
@@ -89451,7 +89451,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     post:
-      description: Update an AI Assistant's attributes.
+      description: Updates the specified AI assistant's attributes and returns the updated assistant. The request can also control how the change is promoted across assistant versions.
       operationId: update_assistant_public_assistants__assistant_id__post
       parameters:
       - description: Unique identifier of the assistant.
@@ -90083,7 +90083,7 @@ paths:
       - Assistants
       x-latency-category: responsive
     get:
-      description: Retrieve a scheduled event by event ID
+      description: Returns the details of a single scheduled event configured for the specified assistant.
       operationId: get_scheduled_event
       parameters:
       - description: Unique identifier of the assistant.
@@ -90187,7 +90187,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tags/{tag}:
     delete:
-      description: Remove a tag from an AI assistant.
+      description: Removes the specified tag from the AI assistant and returns the assistant's updated tag list.
       operationId: remove_assistant_tag
       parameters:
       - description: Unique identifier of the assistant.
@@ -90256,7 +90256,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tools/{tool_id}:
     delete:
-      description: Detach a tool from an AI assistant.
+      description: Detaches the specified tool from the AI assistant so the assistant can no longer invoke it.
       operationId: remove_assistant_tool
       parameters:
       - description: Unique identifier of the assistant.
@@ -90327,7 +90327,7 @@ paths:
       x-latency-category: responsive
   /ai/assistants/{assistant_id}/tools/{tool_id}/test:
     post:
-      description: Test a webhook tool for an assistant
+      description: Executes a test invocation of the specified webhook tool for the assistant and returns the outcome, so you can verify the webhook's behavior before relying on it in conversations.
       operationId: test_assistant_tool_public_assistants__assistant_id__tools__tool_id__test_post
       parameters:
       - description: Unique identifier of the assistant.
@@ -91325,7 +91325,7 @@ paths:
       - AI Collections
       x-latency-category: interactive
     post:
-      description: Attaches a new source to a collection.
+      description: Attaches a new content source to the specified collection and returns the created source. The source's content is ingested and embedded so it becomes searchable within the collection.
       operationId: AddCollectionSource
       parameters:
       - $ref: '#/components/parameters/Uuid'
@@ -91784,7 +91784,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     post:
-      description: Create a new AI Conversation.
+      description: Creates a new AI conversation, the container for messages exchanged with an assistant, and returns the created conversation.
       operationId: create_new_conversation_public_conversations_post
       requestBody:
         content:
@@ -91925,7 +91925,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insight-groups:
     get:
-      description: Get all insight groups
+      description: Returns a paginated list of your insight template groups. Groups organize related insight templates that are applied together when analyzing conversations.
       operationId: get_all_insight_groups
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -91988,7 +91988,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     post:
-      description: Create a new insight group
+      description: Creates a new insight template group for organizing related insight templates, and returns the created group.
       operationId: create_insight_group
       requestBody:
         content:
@@ -92034,7 +92034,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insight-groups/{group_id}:
     delete:
-      description: Delete insight group by ID
+      description: Permanently deletes the specified insight template group by its ID.
       operationId: delete_insight_group_by_id
       parameters:
       - description: The ID of the insight group
@@ -92066,7 +92066,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     get:
-      description: Get insight group by ID
+      description: Returns the details of a single insight template group, including the insight templates assigned to it.
       operationId: get_insight_group_by_id
       parameters:
       - description: The ID of the insight group
@@ -92111,7 +92111,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     put:
-      description: Update an insight template group
+      description: Updates the specified insight template group and returns the updated group.
       operationId: update_insight_group_by_id
       parameters:
       - description: The ID of the insight group
@@ -92167,7 +92167,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insight-groups/{group_id}/insights/{insight_id}/assign:
     post:
-      description: Assign an insight to a group
+      description: Assigns the specified insight template to the specified insight template group.
       operationId: assign_insight_to_group
       parameters:
       - description: The ID of the insight group
@@ -92209,7 +92209,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insight-groups/{group_id}/insights/{insight_id}/unassign:
     delete:
-      description: Remove an insight from a group
+      description: Removes the specified insight template from the specified group. The insight template itself is not deleted.
       operationId: unassign_insight_from_group
       parameters:
       - description: The ID of the insight group
@@ -92251,7 +92251,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insights:
     get:
-      description: Get all insights
+      description: Returns a paginated list of your insight templates. Insight templates define analyses that run over AI conversations to extract structured findings.
       operationId: get_all_insights
       parameters:
       - description: 'Consolidated page parameter (deepObject style). Originally:
@@ -92308,7 +92308,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     post:
-      description: Create a new insight
+      description: Creates a new insight template defining an analysis to run over conversations, and returns the created template.
       operationId: create_insight
       requestBody:
         content:
@@ -92349,7 +92349,7 @@ paths:
       x-latency-category: responsive
   /ai/conversations/insights/{insight_id}:
     delete:
-      description: Delete insight by ID
+      description: Permanently deletes the specified insight template by its ID.
       operationId: delete_insight_by_id
       parameters:
       - description: The ID of the insight
@@ -92381,7 +92381,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     get:
-      description: Get insight by ID
+      description: Returns the details of a single insight template by its ID, including its configuration.
       operationId: get_insight_by_id
       parameters:
       - description: The ID of the insight
@@ -92420,7 +92420,7 @@ paths:
       - Conversations
       x-latency-category: responsive
     put:
-      description: Update an insight template
+      description: Updates the specified insight template and returns the updated template.
       operationId: update_insight_by_id
       parameters:
       - description: The ID of the insight
@@ -92809,7 +92809,7 @@ paths:
       x-latency-category: responsive
   /ai/embeddings/buckets:
     get:
-      description: Get all embedding buckets for a user.
+      description: Returns the list of storage buckets that have been embedded for your account, for use with similarity search.
       operationId: GetEmbeddingBuckets
       responses:
         '200':
@@ -93079,7 +93079,7 @@ paths:
       - Fine Tuning
       x-latency-category: responsive
     post:
-      description: Create a new fine tuning job.
+      description: Creates a new fine-tuning job that trains a model on the provided dataset, and returns the created job.
       operationId: create_new_finetuningjob_public_finetuning_post
       requestBody:
         content:
@@ -93123,7 +93123,7 @@ paths:
       x-latency-category: responsive
   /ai/fine_tuning/jobs/{job_id}:
     get:
-      description: Retrieve a fine tuning job by `job_id`.
+      description: Returns the details of a single fine-tuning job by its job_id, including its current status.
       operationId: get_finetuningjob_public_finetuning__job_id__get
       parameters:
       - description: Unique identifier of the job.
@@ -93163,7 +93163,7 @@ paths:
       x-latency-category: responsive
   /ai/fine_tuning/jobs/{job_id}/cancel:
     post:
-      description: Cancel a fine tuning job.
+      description: Cancels the specified in-progress fine-tuning job and returns the updated job.
       operationId: cancel_new_finetuningjob_public_finetuning_post
       parameters:
       - description: Unique identifier of the job.
@@ -93203,7 +93203,7 @@ paths:
       x-latency-category: responsive
   /ai/integrations:
     get:
-      description: List all available integrations.
+      description: Returns the list of third-party integrations available to connect to your AI assistants and workflows.
       operationId: list_integrations_public_integrations_get
       responses:
         '200':
@@ -93234,7 +93234,7 @@ paths:
       x-latency-category: responsive
   /ai/integrations/connections:
     get:
-      description: List user setup integrations
+      description: Returns the list of integration connections you have set up, linking your account to third-party services.
       operationId: list_user_integrations_public_integrations_connections_get
       responses:
         '200':
@@ -93290,7 +93290,7 @@ paths:
       - Integrations
       x-latency-category: responsive
     get:
-      description: Get user setup integrations
+      description: Returns the details of a single integration connection by its ID.
       operationId: get_user_integration_by_id_public_integrations_connections__user_connection_id__get
       parameters:
       - description: The connection id
@@ -93324,7 +93324,7 @@ paths:
       x-latency-category: responsive
   /ai/integrations/{integration_id}:
     get:
-      description: Retrieve integration details
+      description: Returns the details of a single available integration, including its configuration details.
       operationId: list_integration_by_id_public_integrations__integration_id__get
       parameters:
       - description: The integration id
@@ -93361,7 +93361,7 @@ paths:
       x-latency-category: responsive
   /ai/mcp_servers:
     get:
-      description: Retrieve a list of MCP servers.
+      description: Returns a paginated list of the MCP servers configured on your account, with optional filtering by type or URL.
       operationId: list_mcp_servers
       parameters:
       - description: Filter results by type.
@@ -93421,7 +93421,7 @@ paths:
       - MCP Servers
       x-latency-category: responsive
     post:
-      description: Create a new MCP server.
+      description: Creates a new MCP server configuration on your account and returns the created server.
       operationId: create_mcp_server
       requestBody:
         content:
@@ -93458,7 +93458,7 @@ paths:
       x-latency-category: responsive
   /ai/mcp_servers/{mcp_server_id}:
     delete:
-      description: Delete a specific MCP server.
+      description: Permanently deletes the specified MCP server configuration from your account.
       operationId: delete_mcp_server
       parameters:
       - description: Unique identifier of the mcp server.
@@ -93522,7 +93522,7 @@ paths:
       - MCP Servers
       x-latency-category: responsive
     put:
-      description: Update an existing MCP server.
+      description: Updates the specified MCP server's configuration and returns the updated server.
       operationId: update_mcp_server
       parameters:
       - description: Unique identifier of the mcp server.
@@ -95910,7 +95910,7 @@ paths:
       x-latency-category: responsive
   /ai/tools/{tool_id}:
     delete:
-      description: Delete a custom AI tool.
+      description: Permanently deletes the specified custom AI tool from your account.
       operationId: delete_tool_tool_id
       parameters:
       - description: Unique identifier of the tool.
@@ -96265,7 +96265,7 @@ paths:
       x-latency-category: responsive
     post:
       deprecated: false
-      description: Creates an authentication provider.
+      description: Creates a new authentication provider for single sign-on, configured from the provided identity provider details, and returns the created resource.
       operationId: CreateAuthenticationProvider
       parameters: []
       requestBody:
@@ -96928,7 +96928,7 @@ paths:
       x-latency-category: responsive
   /bundle_pricing/billing_bundles:
     get:
-      description: Get all allowed bundles.
+      description: Returns a paginated list of the billing bundles available to your account, with support for filtering.
       operationId: GetUserBillingBundles
       parameters:
       - $ref: '#/components/parameters/bundle-pricing_FilterConsolidated'
@@ -96953,7 +96953,7 @@ paths:
       x-latency-category: responsive
   /bundle_pricing/billing_bundles/{bundle_id}:
     get:
-      description: Get a single bundle by ID.
+      description: Returns the details of a single billing bundle by its ID, so you can inspect its contents before purchasing a user bundle.
       operationId: GetBillingBundleById
       parameters:
       - $ref: '#/components/parameters/BundleId'
@@ -96977,7 +96977,7 @@ paths:
       x-latency-category: responsive
   /bundle_pricing/user_bundles:
     get:
-      description: Get a paginated list of user bundles.
+      description: Returns a paginated list of the bundles active on your account, with support for filtering.
       operationId: GetUserBundles
       parameters:
       - $ref: '#/components/parameters/bundle-pricing_FilterConsolidated'
@@ -97059,7 +97059,7 @@ paths:
       x-latency-category: responsive
   /bundle_pricing/user_bundles/{user_bundle_id}:
     delete:
-      description: Deactivates a user bundle by its ID.
+      description: Deactivates the specified user bundle on your account and returns the deactivated bundle.
       operationId: DeactivateUserBundle
       parameters:
       - $ref: '#/components/parameters/UserBundleId'
@@ -97084,7 +97084,7 @@ paths:
       - User Bundles
       x-latency-category: responsive
     get:
-      description: Retrieves a user bundle by its ID.
+      description: Returns the details of a single user bundle on your account by its ID.
       operationId: GetUserBundleById
       parameters:
       - $ref: '#/components/parameters/UserBundleId'
@@ -97166,7 +97166,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: interactive
     post:
-      description: Create a call control application.
+      description: Creates a call control application, which defines the webhook endpoints and settings used to control calls on associated connections.
       operationId: CreateCallControlApplication
       requestBody:
         content:
@@ -97195,7 +97195,7 @@ paths:
       x-latency-category: interactive
   /call_control_applications/{id}:
     delete:
-      description: Deletes a call control application.
+      description: Permanently deletes the specified call control application and its webhook configuration.
       operationId: DeleteCallControlApplication
       parameters:
       - description: Identifies the resource.
@@ -97650,7 +97650,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/ai_assistant_stop:
     post:
-      description: Stop an AI assistant on the call.
+      description: Stops the AI assistant currently engaged on the call. The call remains active and can continue with other call control commands.
       operationId: CallStopAIAssistant
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -97780,7 +97780,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/client_state_update:
     put:
-      description: Updates client state
+      description: Updates the client state associated with the call. Client state is an opaque value echoed back in subsequent webhooks for the call, letting you correlate events with your application's state.
       operationId: UpdateClientState
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -97889,7 +97889,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/enqueue:
     post:
-      description: Put the call in a queue.
+      description: Places the call into a queue, where it waits until it is removed or bridged to another leg. Queue behavior is configured through the request body.
       operationId: EnqueueCall
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -98267,7 +98267,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/leave_queue:
     post:
-      description: Removes the call from a queue.
+      description: Removes the call from the queue it is currently waiting in. The call remains active and can be directed with further call commands.
       operationId: LeaveQueue
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -99116,7 +99116,7 @@ paths:
       x-latency-category: interactive
   /calls/{call_control_id}/actions/transcription_stop:
     post:
-      description: Stop real-time transcription.
+      description: Stops real-time transcription on the call. Transcription webhooks cease once the command takes effect; the call itself is unaffected.
       operationId: StopCallTranscription
       parameters:
       - $ref: '#/components/parameters/CallControlId'
@@ -99621,7 +99621,7 @@ paths:
       x-latency-category: interactive
   /conferences/{conference_id}/participants:
     get:
-      description: Lists conference participants
+      description: Returns a paginated list of participants in the specified conference, with support for filtering.
       operationId: ListConferenceParticipants
       parameters:
       - description: Uniquely identifies the conference by id
@@ -99680,7 +99680,7 @@ paths:
       x-latency-category: interactive
   /conferences/{id}:
     get:
-      description: Retrieve an existing conference
+      description: Returns the details of an existing conference, including its current status.
       operationId: RetrieveConference
       parameters:
       - description: Uniquely identifies the conference by id
@@ -99982,7 +99982,7 @@ paths:
       x-latency-category: interactive
   /conferences/{id}/actions/record_pause:
     post:
-      description: Pause conference recording.
+      description: Pauses the active recording of the specified conference. Resume it later with the record_resume action.
       operationId: PauseConferenceRecording
       parameters:
       - description: Specifies the conference by id or name
@@ -100020,7 +100020,7 @@ paths:
       x-latency-category: interactive
   /conferences/{id}/actions/record_resume:
     post:
-      description: Resume conference recording.
+      description: Resumes a previously paused recording of the specified conference, continuing capture from the point it was paused.
       operationId: ResumeConferenceRecording
       parameters:
       - description: Specifies the conference by id or name
@@ -100582,7 +100582,7 @@ paths:
       x-latency-category: responsive
   /country_coverage:
     get:
-      description: Get country coverage
+      description: Returns Telnyx service coverage information for every country, including which number types and features are available in each.
       operationId: retreiveCountryCoverage
       responses:
         '200':
@@ -100697,7 +100697,7 @@ paths:
       x-latency-category: responsive
   /country_coverage/countries/{country_code}:
     get:
-      description: Get coverage for a specific country
+      description: Returns Telnyx service coverage information for the specified country, including available number types and features.
       operationId: retreiveSpecificCountryCoverage
       parameters:
       - description: Country ISO code.
@@ -100767,7 +100767,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Creates a credential connection.
+      description: Creates a new credential-based SIP connection. Credential connections authenticate with a username and password rather than by IP address.
       operationId: CreateCredentialConnection
       parameters: []
       requestBody:
@@ -101095,7 +101095,7 @@ paths:
       x-latency-category: responsive
   /customer_service_records:
     get:
-      description: List customer service records.
+      description: Returns a paginated list of your customer service record (CSR) requests, with support for filtering and sorting.
       operationId: ListCustomerServiceRecords
       parameters:
       - $ref: '#/components/parameters/customer_service_record_PageConsolidated'
@@ -101212,7 +101212,7 @@ paths:
       x-latency-category: responsive
   /customer_service_records/{customer_service_record_id}:
     get:
-      description: Get a specific customer service record.
+      description: Returns the details of a single customer service record (CSR) request, including its status and any retrieved record data.
       operationId: GetCustomerServiceRecord
       parameters:
       - $ref: '#/components/parameters/PathCustomerServiceRecordId'
@@ -101437,7 +101437,7 @@ paths:
       x-latency-category: interactive
   /dialogflow_connections/{connection_id}:
     delete:
-      description: Deletes a stored Dialogflow Connection.
+      description: Deletes the stored Dialogflow connection for the specified connection.
       operationId: DeleteDialogflowConnection
       parameters:
       - $ref: '#/components/parameters/media-streaming_ConnectionId'
@@ -101499,7 +101499,7 @@ paths:
       - Dialogflow Integration
       x-latency-category: responsive
     put:
-      description: Updates a stored Dialogflow Connection.
+      description: Updates the stored Dialogflow connection for the specified connection and returns the updated configuration.
       operationId: UpdateDialogflowConnection
       parameters:
       - $ref: '#/components/parameters/media-streaming_ConnectionId'
@@ -102483,7 +102483,7 @@ paths:
       - Documents
       x-latency-category: responsive
     get:
-      description: Retrieve a document.
+      description: Returns the details of a single document on your account, including its metadata.
       operationId: RetrieveDocument
       parameters:
       - $ref: '#/components/parameters/Id'
@@ -102517,7 +102517,7 @@ paths:
       - Documents
       x-latency-category: responsive
     patch:
-      description: Update a document.
+      description: Updates the specified document's attributes and returns the updated document.
       operationId: UpdateDocument
       parameters:
       - $ref: '#/components/parameters/Id'
@@ -102558,7 +102558,7 @@ paths:
       x-latency-category: responsive
   /documents/{id}/download:
     get:
-      description: Download a document.
+      description: Downloads the raw file content of the specified document as originally uploaded.
       operationId: DownloadDocument
       parameters:
       - $ref: '#/components/parameters/Id'
@@ -102689,7 +102689,7 @@ paths:
       - Dynamic Emergency Addresses
       x-latency-category: responsive
     post:
-      description: Creates a dynamic emergency address.
+      description: Creates a dynamic emergency address, the validated physical location used when provisioning dynamic emergency endpoints.
       operationId: CreateDynamicEmergencyAddress
       requestBody:
         content:
@@ -102846,7 +102846,7 @@ paths:
       - Dynamic Emergency Endpoints
       x-latency-category: responsive
     post:
-      description: Creates a dynamic emergency endpoints.
+      description: Creates a dynamic emergency endpoint, associating a callback number and location with a device for emergency calling.
       operationId: CreateDynamicEmergencyEndpoint
       requestBody:
         content:
@@ -106667,7 +106667,7 @@ paths:
       - Email Templates
       x-latency-category: responsive
     patch:
-      description: Updates one or more template fields.
+      description: Updates one or more fields of the specified email template and returns the updated template.
       operationId: UpdateEmailTemplate
       parameters:
       - $ref: '#/components/parameters/TemplateId'
@@ -109686,7 +109686,7 @@ paths:
       - Programmable Fax Commands
       x-latency-category: responsive
     get:
-      description: Retrieve the details of a single fax.
+      description: Returns the details of a single fax, including its current status.
       operationId: ViewFax
       parameters:
       - description: The unique identifier of a fax.
@@ -109832,7 +109832,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Creates a FQDN connection.
+      description: Creates a new FQDN-based SIP connection. FQDN connections authenticate by your registered domain names rather than static IP addresses.
       operationId: CreateFqdnConnection
       parameters: []
       requestBody:
@@ -109942,7 +109942,7 @@ paths:
       x-latency-category: responsive
   /fqdn_connections/{id}:
     delete:
-      description: Deletes an FQDN connection.
+      description: Permanently deletes the specified FQDN connection from your account.
       operationId: DeleteFqdnConnection
       parameters:
       - $ref: '#/components/parameters/connections_id'
@@ -110099,7 +110099,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a new FQDN object.
+      description: Creates a new FQDN record and attaches it to the specified connection.
       operationId: CreateFqdn
       requestBody:
         content:
@@ -110130,7 +110130,7 @@ paths:
       x-latency-category: responsive
   /fqdns/{id}:
     delete:
-      description: Delete an FQDN.
+      description: Permanently deletes the specified FQDN record from its connection.
       operationId: DeleteFqdn
       parameters:
       - $ref: '#/components/parameters/FqdnId'
@@ -110186,7 +110186,7 @@ paths:
       - FQDNs
       x-latency-category: responsive
     patch:
-      description: Update the details of a specific FQDN.
+      description: Updates the details of the specified FQDN record and returns the updated FQDN.
       operationId: UpdateFqdn
       parameters:
       - $ref: '#/components/parameters/FqdnId'
@@ -111604,7 +111604,7 @@ paths:
       x-latency-category: responsive
   /invoices:
     get:
-      description: Retrieve a paginated list of invoices.
+      description: Returns a paginated list of your invoices, with support for sorting.
       operationId: ListInvoices
       parameters:
       - description: Specifies the sort order for results.
@@ -111714,7 +111714,7 @@ paths:
       x-latency-category: responsive
   /ip_connections:
     get:
-      description: Returns a list of your IP connections.
+      description: Returns a paginated list of your IP-based SIP connections, with support for filtering and sorting.
       operationId: ListIpConnections
       parameters:
       - $ref: '#/components/parameters/connections_FilterConsolidated'
@@ -111748,7 +111748,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Creates an IP connection.
+      description: Creates a new IP-based SIP connection, which authenticates traffic by source IP address.
       operationId: CreateIpConnection
       parameters: []
       requestBody:
@@ -111782,7 +111782,7 @@ paths:
       x-latency-category: responsive
   /ip_connections/{id}:
     delete:
-      description: Deletes an existing IP connection.
+      description: Permanently deletes the specified IP connection from your account.
       operationId: DeleteIpConnection
       parameters:
       - description: Identifies the type of resource.
@@ -111952,7 +111952,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a new IP object.
+      description: Creates a new IP record for use with IP-based connections, associating an IP address with the specified connection.
       operationId: CreateIp
       requestBody:
         content:
@@ -111983,7 +111983,7 @@ paths:
       x-latency-category: responsive
   /ips/{id}:
     delete:
-      description: Delete an IP.
+      description: Permanently deletes the specified IP record from its connection.
       operationId: DeleteIp
       parameters:
       - $ref: '#/components/parameters/IpId'
@@ -112039,7 +112039,7 @@ paths:
       - IPs
       x-latency-category: responsive
     patch:
-      description: Update the details of a specific IP.
+      description: Updates the details of the specified IP record and returns the updated IP.
       operationId: UpdateIp
       parameters:
       - $ref: '#/components/parameters/IpId'
@@ -112745,7 +112745,7 @@ paths:
       - MDR Usage Reports
       x-latency-category: responsive
     get:
-      description: Fetch single MDR usage report by id.
+      description: Returns a single MDR (Message Detail Record) usage report by its identifier, including its parameters and current status.
       operationId: getMdrUsageReport
       parameters:
       - description: Unique identifier of the resource.
@@ -112811,7 +112811,7 @@ paths:
       - Telco Data Usage Reports
       x-latency-category: responsive
     post:
-      description: Submit a new telco data usage report
+      description: Submits a new telco data (number lookup) usage report request. The report is generated asynchronously; retrieve it by its identifier once ready.
       operationId: submitTelcoDataUsageReport
       requestBody:
         content:
@@ -113046,7 +113046,7 @@ paths:
       - CDR Usage Reports
       x-latency-category: responsive
     get:
-      description: Fetch single cdr usage report by id.
+      description: Returns a single CDR (Call Detail Record) usage report by its identifier, including its parameters and current status.
       operationId: getCdrUsageReport
       parameters:
       - description: Unique identifier of the resource.
@@ -113429,7 +113429,7 @@ paths:
       - MDR Usage Reports
       x-latency-category: responsive
     get:
-      description: Fetch single MDR usage report by id.
+      description: Returns a single MDR (Message Detail Record) usage report by its identifier, including its parameters and current status.
       operationId: getMdrUsageReport
       parameters:
       - description: Unique identifier of the resource.
@@ -113495,7 +113495,7 @@ paths:
       - Telco Data Usage Reports
       x-latency-category: responsive
     post:
-      description: Submit a new telco data usage report
+      description: Submits a new telco data (number lookup) usage report request. The report is generated asynchronously; retrieve it by its identifier once ready.
       operationId: submitTelcoDataUsageReport
       requestBody:
         content:
@@ -113730,7 +113730,7 @@ paths:
       - CDR Usage Reports
       x-latency-category: responsive
     get:
-      description: Fetch single cdr usage report by id.
+      description: Returns a single CDR (Call Detail Record) usage report by its identifier, including its parameters and current status.
       operationId: getCdrUsageReport
       parameters:
       - description: Unique identifier of the resource.
@@ -113981,7 +113981,7 @@ paths:
       - Managed Accounts
       x-latency-category: responsive
     patch:
-      description: Update a single managed account.
+      description: Updates the specified managed account's attributes and returns the updated account.
       operationId: UpdateManagedAccount
       parameters:
       - description: Managed Account User ID
@@ -114145,7 +114145,7 @@ paths:
       x-latency-category: responsive
   /media:
     get:
-      description: Returns a list of stored media files.
+      description: Returns a list of the media files stored on your account, with support for filtering.
       operationId: ListMediaStorage
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -114223,7 +114223,7 @@ paths:
       x-latency-category: interactive
   /media/{media_name}:
     delete:
-      description: Deletes a stored media file.
+      description: Permanently deletes the specified media file from storage.
       operationId: DeleteMediaStorage
       parameters:
       - $ref: '#/components/parameters/MediaName'
@@ -114267,7 +114267,7 @@ paths:
       - Media Storage API
       x-latency-category: interactive
     put:
-      description: Updates a stored media file.
+      description: Updates the specified stored media file and returns the updated resource.
       operationId: UpdateMediaStorage
       parameters:
       - $ref: '#/components/parameters/MediaName'
@@ -114306,7 +114306,7 @@ paths:
       x-latency-category: interactive
   /media/{media_name}/download:
     get:
-      description: Downloads a stored media file.
+      description: Downloads the raw content of the specified stored media file.
       operationId: DownloadMedia
       parameters:
       - $ref: '#/components/parameters/MediaName'
@@ -116574,7 +116574,7 @@ paths:
       x-latency-category: responsive
   /messaging_optouts:
     get:
-      description: Retrieve a list of opt-out blocks.
+      description: Returns a paginated list of opt-out blocks created when message recipients opt out. Supports filtering and optional redaction of recipient numbers.
       operationId: ListOptOuts
       parameters:
       - description: If receiving address (+E.164 formatted phone number) should be
@@ -117648,7 +117648,7 @@ paths:
       x-latency-category: responsive
   /mobile_push_credentials:
     get:
-      description: List mobile push credentials
+      description: Returns a paginated list of the mobile push credentials on your account, with support for filtering.
       operationId: ListPushCredentials
       parameters:
       - $ref: '#/components/parameters/push-notifications_PageConsolidated'
@@ -117690,7 +117690,7 @@ paths:
       - Push Credentials
       x-latency-category: responsive
     post:
-      description: Creates a new mobile push credential
+      description: Creates a new mobile push credential for delivering push notifications to iOS or Android apps, and returns the created credential.
       operationId: CreatePushCredential
       parameters: []
       requestBody:
@@ -117882,7 +117882,7 @@ paths:
       x-latency-category: responsive
   /networks:
     get:
-      description: List all Networks.
+      description: Returns a paginated list of the private networks on your account, with support for filtering.
       operationId: ListNetworks
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -117922,7 +117922,7 @@ paths:
       - Networks
       x-latency-category: responsive
     post:
-      description: Create a new Network.
+      description: Creates a new private network, the container that links your WireGuard interfaces, gateways, and cross connects.
       operationId: CreateNetwork
       requestBody:
         content:
@@ -117950,7 +117950,7 @@ paths:
       x-latency-category: responsive
   /networks/{id}:
     delete:
-      description: Delete a Network.
+      description: Permanently deletes the specified network from your account.
       operationId: DeleteNetwork
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -117973,7 +117973,7 @@ paths:
       - Networks
       x-latency-category: responsive
     get:
-      description: Retrieve a Network.
+      description: Returns the details of a single network by its identifier.
       operationId: GetNetwork
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -117996,7 +117996,7 @@ paths:
       - Networks
       x-latency-category: responsive
     patch:
-      description: Update a Network.
+      description: Updates the specified network's attributes and returns the updated network.
       operationId: UpdateNetwork
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -118026,7 +118026,7 @@ paths:
       x-latency-category: responsive
   /networks/{id}/default_gateway:
     delete:
-      description: Delete Default Gateway.
+      description: Removes the default gateway from the specified network.
       operationId: DeleteDefaultGateway
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -118053,7 +118053,7 @@ paths:
       - Networks
       x-latency-category: responsive
     get:
-      description: Get Default Gateway status.
+      description: Returns the status of the default gateway configured on the specified network.
       operationId: GetDefaultGateway
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -118080,7 +118080,7 @@ paths:
       - Networks
       x-latency-category: responsive
     post:
-      description: Create Default Gateway.
+      description: Creates a default gateway on the specified network, directing the network's outbound traffic through the chosen gateway.
       operationId: CreateDefaultGateway
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -118114,7 +118114,7 @@ paths:
       x-latency-category: responsive
   /networks/{id}/network_interfaces:
     get:
-      description: List all Interfaces for a Network.
+      description: Returns a paginated list of the interfaces attached to the specified network, with support for filtering.
       operationId: ListNetworkInterfaces
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -118163,7 +118163,7 @@ paths:
       x-latency-category: responsive
   /notification_channels:
     get:
-      description: List notification channels.
+      description: Returns a paginated list of your notification channels, the destinations that receive notifications.
       operationId: ListNotificationChannels
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -118193,7 +118193,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     post:
-      description: Create a notification channel.
+      description: Creates a new notification channel defining where notifications are delivered, and returns the created channel.
       operationId: CreateNotificationChannels
       requestBody:
         content:
@@ -118223,7 +118223,7 @@ paths:
       x-latency-category: responsive
   /notification_channels/{id}:
     delete:
-      description: Delete a notification channel.
+      description: Deletes the specified notification channel so notifications are no longer delivered to it.
       operationId: DeleteNotificationChannel
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118248,7 +118248,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     get:
-      description: Get a notification channel.
+      description: Returns the details of a single notification channel by its identifier.
       operationId: GetNotificationChannel
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118275,7 +118275,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     patch:
-      description: Update a notification channel.
+      description: Updates the specified notification channel and returns the updated channel.
       operationId: UpdateNotificationChannel
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118398,7 +118398,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     post:
-      description: Create a notification profile.
+      description: Creates a new notification profile, a named grouping used to organize notification settings, and returns it.
       operationId: CreateNotificationProfile
       requestBody:
         content:
@@ -118428,7 +118428,7 @@ paths:
       x-latency-category: responsive
   /notification_profiles/{id}:
     delete:
-      description: Delete a notification profile.
+      description: Deletes the specified notification profile from your account.
       operationId: DeleteNotificationProfile
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118453,7 +118453,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     get:
-      description: Get a notification profile.
+      description: Returns the details of a single notification profile by its identifier.
       operationId: GetNotificationProfile
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118480,7 +118480,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     patch:
-      description: Update a notification profile.
+      description: Updates the specified notification profile and returns the updated profile.
       operationId: UpdateNotificationProfile
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118513,7 +118513,7 @@ paths:
       x-latency-category: responsive
   /notification_settings:
     get:
-      description: List notification settings.
+      description: Returns a paginated list of your notification settings, which map notification event types to profiles and channels.
       operationId: ListNotificationSettings
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -118543,7 +118543,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     post:
-      description: Add a notification setting.
+      description: Adds a notification setting that enables delivery of a notification event type to a notification profile.
       operationId: CreateNotificationSetting
       requestBody:
         content:
@@ -118581,7 +118581,7 @@ paths:
       x-latency-category: responsive
   /notification_settings/{id}:
     delete:
-      description: Delete a notification setting.
+      description: Deletes the specified notification setting, disabling that notification delivery.
       operationId: DeleteNotificationSetting
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118615,7 +118615,7 @@ paths:
       - Notifications
       x-latency-category: responsive
     get:
-      description: Get a notification setting.
+      description: Returns the details of a single notification setting by its identifier.
       operationId: GetNotificationSetting
       parameters:
       - $ref: '#/components/parameters/notifications_Id'
@@ -118707,7 +118707,7 @@ paths:
       - Phone Number Block Orders
       x-latency-category: responsive
     post:
-      description: Creates a phone number block order.
+      description: Creates an order for a block of consecutive phone numbers and returns the created order. Track fulfillment through the order's status.
       operationId: CreateNumberBlockOrder
       requestBody:
         content:
@@ -118984,7 +118984,7 @@ paths:
       x-latency-category: responsive
   /number_orders:
     get:
-      description: Get a paginated list of number orders.
+      description: Returns a paginated list of your phone number orders, with support for filtering.
       operationId: ListNumberOrders
       parameters:
       - $ref: '#/components/parameters/numbers_PageConsolidated'
@@ -119053,7 +119053,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Creates a phone number order.
+      description: Creates an order to purchase the specified phone numbers and returns the created order. Track fulfillment through the order's status.
       operationId: CreateNumberOrder
       requestBody:
         content:
@@ -119089,7 +119089,7 @@ paths:
       x-latency-category: responsive
   /number_orders/{number_order_id}:
     get:
-      description: Get an existing phone number order.
+      description: Returns the details of an existing phone number order, including its status and the numbers included.
       operationId: RetrieveNumberOrder
       parameters:
       - description: The number order ID.
@@ -119124,7 +119124,7 @@ paths:
       - Phone Number Orders
       x-latency-category: responsive
     patch:
-      description: Updates a phone number order.
+      description: Updates an existing phone number order, for example to satisfy regulatory requirements attached to the order, and returns the updated order.
       operationId: UpdateNumberOrder
       parameters:
       - description: The number order ID.
@@ -119266,7 +119266,7 @@ paths:
       x-latency-category: responsive
   /number_reservations/{number_reservation_id}:
     get:
-      description: Gets a single phone number reservation.
+      description: Returns the details of a single phone number reservation, including its status and the reserved numbers.
       operationId: RetrieveNumberReservation
       parameters:
       - description: The number reservation ID.
@@ -119583,7 +119583,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     post:
-      description: Create a new OAuth client
+      description: Creates a new OAuth client on your account for authenticating third-party integrations, and returns the created client.
       operationId: CreateOAuthClient
       requestBody:
         content:
@@ -119642,7 +119642,7 @@ paths:
       x-latency-category: responsive
   /oauth/clients/{id}:
     delete:
-      description: Delete an OAuth client
+      description: Permanently deletes the specified OAuth client from your account.
       operationId: DeleteOAuthClient
       parameters:
       - description: OAuth client ID
@@ -119669,7 +119669,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     get:
-      description: Retrieve a single OAuth client by ID
+      description: Returns the details of a single OAuth client on your account by its ID.
       operationId: GetOAuthClient
       parameters:
       - description: OAuth client ID
@@ -119717,7 +119717,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     put:
-      description: Update an existing OAuth client
+      description: Updates the specified OAuth client's configuration and returns the updated client.
       operationId: UpdateOAuthClient
       parameters:
       - description: OAuth client ID
@@ -119816,7 +119816,7 @@ paths:
       x-latency-category: responsive
   /oauth/grants:
     post:
-      description: Create an OAuth authorization grant
+      description: Creates an OAuth authorization grant and returns the grant response for completing the authorization flow.
       operationId: CreateOAuthGrant
       requestBody:
         content:
@@ -119848,7 +119848,7 @@ paths:
       x-latency-category: responsive
   /oauth/grants/{id}:
     delete:
-      description: Revoke an OAuth grant
+      description: Revokes the specified OAuth grant, withdrawing the access previously granted to the client.
       operationId: RevokeOAuthGrant
       parameters:
       - description: OAuth grant ID
@@ -119887,7 +119887,7 @@ paths:
       - OAuth Grants
       x-latency-category: responsive
     get:
-      description: Retrieve a single OAuth grant by ID
+      description: Returns the details of a single OAuth grant on your account by its ID.
       operationId: GetOAuthGrant
       parameters:
       - description: OAuth grant ID
@@ -120220,7 +120220,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     post:
-      description: Create a new OAuth client
+      description: Creates a new OAuth client on your account for authenticating third-party integrations, and returns the created client.
       operationId: CreateOAuthClient
       requestBody:
         content:
@@ -120279,7 +120279,7 @@ paths:
       x-latency-category: responsive
   /oauth_clients/{id}:
     delete:
-      description: Delete an OAuth client
+      description: Permanently deletes the specified OAuth client from your account.
       operationId: DeleteOAuthClient
       parameters:
       - description: OAuth client ID
@@ -120306,7 +120306,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     get:
-      description: Retrieve a single OAuth client by ID
+      description: Returns the details of a single OAuth client on your account by its ID.
       operationId: GetOAuthClient
       parameters:
       - description: OAuth client ID
@@ -120354,7 +120354,7 @@ paths:
       - OAuth Clients
       x-latency-category: responsive
     put:
-      description: Update an existing OAuth client
+      description: Updates the specified OAuth client's configuration and returns the updated client.
       operationId: UpdateOAuthClient
       parameters:
       - description: OAuth client ID
@@ -120479,7 +120479,7 @@ paths:
       x-latency-category: responsive
   /oauth_grants/{id}:
     delete:
-      description: Revoke an OAuth grant
+      description: Revokes the specified OAuth grant, withdrawing the access previously granted to the client.
       operationId: RevokeOAuthGrant
       parameters:
       - description: OAuth grant ID
@@ -120518,7 +120518,7 @@ paths:
       - OAuth Grants
       x-latency-category: responsive
     get:
-      description: Retrieve a single OAuth grant by ID
+      description: Returns the details of a single OAuth grant on your account by its ID.
       operationId: GetOAuthGrant
       parameters:
       - description: OAuth grant ID
@@ -120718,7 +120718,7 @@ paths:
       x-latency-category: interactive
   /organizations/users/{id}:
     get:
-      description: Returns a user in your organization.
+      description: Returns the details of a user in your organization, optionally including the groups the user belongs to.
       operationId: GetOrganizationUser
       parameters:
       - description: Organization User ID
@@ -120755,7 +120755,7 @@ paths:
       x-latency-category: interactive
   /organizations/users/{id}/actions/remove:
     post:
-      description: Deletes a user in your organization.
+      description: Removes the specified user from your organization and returns the result of the removal.
       operationId: DeleteOrganizationUser
       parameters:
       - description: Organization User ID
@@ -120878,7 +120878,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create an outbound voice profile.
+      description: Creates a new outbound voice profile defining calling permissions, destinations, and limits for outbound calls, and returns the created profile.
       operationId: CreateVoiceProfile
       requestBody:
         content:
@@ -125486,7 +125486,7 @@ paths:
       x-latency-category: responsive
   /portouts/events:
     get:
-      description: Returns a list of all port-out events.
+      description: Returns a paginated list of port-out events on your account, such as status changes on port-out requests, with support for filtering.
       operationId: listPortoutEvents
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -125550,7 +125550,7 @@ paths:
       x-latency-category: responsive
   /portouts/events/{id}:
     get:
-      description: Show a specific port-out event.
+      description: Returns the details of a single port-out event, including its type and payload.
       operationId: showPortoutEvent
       parameters:
       - description: Identifies the port-out event.
@@ -125580,7 +125580,7 @@ paths:
       x-latency-category: responsive
   /portouts/events/{id}/republish:
     post:
-      description: Republish a specific port-out event.
+      description: Republishes the specified port-out event, triggering re-delivery of the corresponding webhook to your account.
       operationId: republishPortoutEvent
       parameters:
       - description: Identifies the port-out event.
@@ -125829,7 +125829,7 @@ paths:
       - Number Portout
       x-latency-category: responsive
     post:
-      description: Creates a comment on a portout request.
+      description: Creates a comment on the specified port-out request and returns the created comment.
       operationId: PostPortRequestComment
       parameters:
       - description: Portout id
@@ -125968,7 +125968,7 @@ paths:
       x-latency-category: responsive
   /portouts/{id}/{status}:
     patch:
-      description: Authorize or reject portout request
+      description: Updates the status of the specified port-out request, using the status path segment to authorize or reject the port-out.
       operationId: UpdatePortoutStatus
       parameters:
       - description: Portout id
@@ -126301,7 +126301,7 @@ paths:
       x-latency-category: background
   /private_wireless_gateways/{id}:
     delete:
-      description: Deletes the Private Wireless Gateway.
+      description: Permanently deletes the specified Private Wireless Gateway from your account.
       operationId: DeleteWirelessGateway
       parameters:
       - $ref: '#/components/parameters/PrivateWirelessGatewayId'
@@ -126588,7 +126588,7 @@ paths:
       x-latency-category: interactive
   /public_internet_gateways:
     get:
-      description: List all Public Internet Gateways.
+      description: Returns a paginated list of the public internet gateways on your account, with support for filtering.
       operationId: ListPublicInternetGateways
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -126628,7 +126628,7 @@ paths:
       - Public Internet Gateways
       x-latency-category: responsive
     post:
-      description: Create a new Public Internet Gateway.
+      description: Requests creation of a public internet gateway on the specified network, giving the network internet egress. Creation is asynchronous, so the request is accepted and completes in the background.
       operationId: CreatePublicInternetGateway
       requestBody:
         content:
@@ -126656,7 +126656,7 @@ paths:
       x-latency-category: responsive
   /public_internet_gateways/{id}:
     delete:
-      description: Delete a Public Internet Gateway.
+      description: Deletes the specified public internet gateway, removing internet egress through it.
       operationId: DeletePublicInternetGateway
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -126679,7 +126679,7 @@ paths:
       - Public Internet Gateways
       x-latency-category: responsive
     get:
-      description: Retrieve a Public Internet Gateway.
+      description: Returns the details of a single public internet gateway by its identifier.
       operationId: GetPublicInternetGateway
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -126747,7 +126747,7 @@ paths:
       - Queue Commands
       x-latency-category: interactive
     post:
-      description: Create a new call queue.
+      description: Creates a new call queue with the provided configuration and returns the created queue.
       operationId: CreateQueue
       requestBody:
         content:
@@ -126775,7 +126775,7 @@ paths:
       x-latency-category: interactive
   /queues/{queue_name}:
     delete:
-      description: Delete an existing call queue.
+      description: Permanently deletes the specified call queue from your account.
       operationId: DeleteQueue
       parameters:
       - description: Uniquely identifies the queue by name
@@ -126796,7 +126796,7 @@ paths:
       - Queue Commands
       x-latency-category: interactive
     get:
-      description: Retrieve an existing call queue
+      description: Returns the details of an existing call queue, including its current configuration.
       operationId: RetrieveCallQueue
       parameters:
       - description: Uniquely identifies the queue by name
@@ -127497,7 +127497,7 @@ paths:
       x-latency-category: responsive
   /recordings:
     get:
-      description: Returns a list of your call recordings.
+      description: Returns a paginated list of your call recordings, with support for filtering to locate specific recordings.
       operationId: GetRecordings
       parameters:
       - $ref: '#/components/parameters/call-recordings_PageConsolidated'
@@ -127656,7 +127656,7 @@ paths:
       x-latency-category: responsive
   /recordings/{recording_id}:
     delete:
-      description: Permanently deletes a call recording.
+      description: Permanently deletes the specified call recording and returns the deleted recording resource. The media is removed and can no longer be downloaded.
       operationId: DeleteRecording
       parameters:
       - $ref: '#/components/parameters/RecordingId'
@@ -128019,7 +128019,7 @@ paths:
       x-latency-category: background
   /reports/mdr_usage_reports/{id}:
     delete:
-      description: Delete messaging usage report by id
+      description: Permanently deletes the specified messaging usage report by its identifier.
       operationId: DeleteUsageReport
       parameters:
       - description: Unique identifier of the resource.
@@ -128076,7 +128076,7 @@ paths:
       x-latency-category: interactive
   /reports/mdrs:
     get:
-      description: 'Fetch all Mdr records '
+      description: Returns message detail records (MDRs) matching the provided criteria, such as date range, direction, status, and message type.
       operationId: GetPaginatedMdrs
       parameters:
       - description: Pagination start date
@@ -128171,7 +128171,7 @@ paths:
       x-latency-category: interactive
   /reports/wdrs:
     get:
-      description: 'Fetch all Wdr records '
+      description: Returns wireless detail records (WDRs) matching the provided criteria, such as date range, SIM card, IMSI, or phone number, with pagination and sorting.
       operationId: GetPaginatedWdrs
       parameters:
       - description: Start date
@@ -128709,7 +128709,7 @@ paths:
       x-latency-category: responsive
   /requirement_types/{id}:
     get:
-      description: Retrieve a requirement type by id
+      description: Returns the details of a single requirement type by its identifier, describing a kind of documentation needed for regulatory purposes.
       operationId: RetrieveRequirementType
       parameters:
       - $ref: '#/components/parameters/DocReqsRequirementTypeId'
@@ -128784,7 +128784,7 @@ paths:
       x-latency-category: responsive
   /requirements/{id}:
     get:
-      description: Retrieve a document requirement record
+      description: Returns a single document requirement record by its identifier, describing the documentation needed for number-related actions. A specific requirement version can be requested.
       operationId: RetrieveDocumentRequirements
       parameters:
       - $ref: '#/components/parameters/DocReqsRequirementId'
@@ -129441,7 +129441,7 @@ paths:
       x-latency-category: responsive
   /room_recordings/{room_recording_id}:
     delete:
-      description: Synchronously delete a Room Recording.
+      description: Synchronously deletes the specified video room recording. The recording's media is removed permanently.
       operationId: DeleteRoomRecording
       parameters:
       - description: The unique identifier of a room recording.
@@ -130027,7 +130027,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     post:
-      description: Synchronously create a Room.
+      description: Synchronously creates a new video room with the provided configuration and returns the created room.
       operationId: CreateRoom
       requestBody:
         content:
@@ -130116,7 +130116,7 @@ paths:
       x-endpoint-cost: light
       x-latency-category: responsive
     patch:
-      description: Synchronously update a Room.
+      description: Synchronously updates the specified video room's configuration and returns the updated room.
       operationId: UpdateRoom
       parameters:
       - description: The unique identifier of a room.
@@ -131086,7 +131086,7 @@ paths:
       - SIM Card Groups
       x-latency-category: responsive
     post:
-      description: Creates a new SIM card group object
+      description: Creates a new SIM card group and returns it. Groups let you apply shared settings to a set of SIM cards.
       operationId: CreateSimCardGroup
       requestBody:
         content:
@@ -131114,7 +131114,7 @@ paths:
       x-latency-category: responsive
   /sim_card_groups/{id}:
     delete:
-      description: Permanently deletes a SIM card group
+      description: Permanently deletes the specified SIM card group from your account.
       operationId: DeleteSimCardGroup
       parameters:
       - $ref: '#/components/parameters/SIMCardGroupId'
@@ -131161,7 +131161,7 @@ paths:
       - SIM Card Groups
       x-latency-category: responsive
     patch:
-      description: Updates a SIM card group
+      description: Updates the specified SIM card group's attributes and returns the updated group.
       operationId: UpdateSimCardGroup
       parameters:
       - $ref: '#/components/parameters/SIMCardGroupId'
@@ -131328,7 +131328,7 @@ paths:
       x-latency-category: background
   /sim_card_order_preview:
     post:
-      description: Preview SIM card order purchases.
+      description: Previews a SIM card order purchase, returning estimated costs and details before you place the order. The preview is processed asynchronously.
       operationId: PreviewSimCardOrders
       requestBody:
         content:
@@ -131395,7 +131395,7 @@ paths:
       - SIM Card Orders
       x-latency-category: responsive
     post:
-      description: Creates a new order for SIM cards.
+      description: Creates a new order for physical SIM cards, including quantity and shipping details, and returns the created order.
       operationId: CreateSimCardOrder
       requestBody:
         content:
@@ -131423,7 +131423,7 @@ paths:
       x-latency-category: responsive
   /sim_card_orders/{id}:
     get:
-      description: Get a single SIM card order by its ID.
+      description: Returns the details of a single SIM card order by its ID, including its status.
       operationId: GetSimCardOrder
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -131749,7 +131749,7 @@ paths:
       - SIM Cards
       x-latency-category: responsive
     patch:
-      description: Updates SIM card data
+      description: Updates the specified SIM card's attributes and returns the updated SIM card.
       operationId: UpdateSimCard
       parameters:
       - $ref: '#/components/parameters/SIMCardId'
@@ -132363,7 +132363,7 @@ paths:
       x-latency-category: responsive
   /siprec_connectors/{connector_name}:
     delete:
-      description: Deletes a stored SIPREC connector.
+      description: Deletes the stored SIPREC connector with the specified connector name.
       operationId: deleteSiprecConnector
       parameters:
       - $ref: '#/components/parameters/SiprecConnectorName'
@@ -134069,7 +134069,7 @@ paths:
   /storage/migrations/{id}/actions/stop:
     post:
       deprecated: false
-      description: Stop an in-progress storage migration.
+      description: Stops the specified in-progress storage migration and returns the updated migration.
       operationId: StopMigration
       parameters:
       - description: Unique identifier for the data migration.
@@ -134663,7 +134663,7 @@ paths:
       x-latency-category: responsive
   /sub_number_orders/{sub_number_order_id}:
     get:
-      description: Get an existing sub number order.
+      description: Returns the details of an existing sub number order, with support for filtering.
       operationId: GetSubNumberOrder
       parameters:
       - description: The sub number order ID.
@@ -134711,7 +134711,7 @@ paths:
       - Phone Number Orders
       x-latency-category: responsive
     patch:
-      description: Updates a sub number order.
+      description: Updates the requirements of an existing sub number order and returns the updated order.
       operationId: UpdateSubNumberOrder
       parameters:
       - description: The sub number order ID.
@@ -134902,7 +134902,7 @@ paths:
       x-latency-category: background
   /telephony_credentials:
     get:
-      description: List all On-demand Credentials.
+      description: Returns a paginated list of the on-demand telephony credentials on your account, with support for filtering.
       operationId: FindTelephonyCredentials
       parameters:
       - $ref: '#/components/parameters/telephony-credentials_PageConsolidated'
@@ -134934,7 +134934,7 @@ paths:
       x-group-parameters: 'true'
       x-latency-category: responsive
     post:
-      description: Create a credential.
+      description: Creates a new on-demand telephony credential for the specified connection. The credential can then be used to generate access tokens for SIP or WebRTC clients.
       operationId: CreateTelephonyCredential
       parameters: []
       requestBody:
@@ -134963,7 +134963,7 @@ paths:
       x-latency-category: responsive
   /telephony_credentials/{id}:
     delete:
-      description: Delete an existing credential.
+      description: Permanently deletes the specified telephony credential, revoking any access it provided.
       operationId: DeleteTelephonyCredential
       parameters:
       - description: Identifies the resource.
@@ -135025,7 +135025,7 @@ paths:
       - Credentials
       x-latency-category: responsive
     patch:
-      description: Update an existing credential.
+      description: Updates the specified telephony credential and returns the updated credential.
       operationId: UpdateTelephonyCredential
       parameters:
       - description: Identifies the resource.
@@ -135544,7 +135544,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Conferences:
     get:
-      description: Lists conference resources.
+      description: Returns a paginated list of conference resources for the account, with support for filtering by friendly name, status, and creation or update dates.
       operationId: GetTexmlConferences
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135570,7 +135570,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Conferences/{conference_sid}:
     get:
-      description: Returns a conference resource.
+      description: Returns a single conference resource for the account by its ConferenceSid.
       operationId: GetTexmlConference
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135589,7 +135589,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     post:
-      description: Updates a conference resource.
+      description: Updates the specified conference resource, for example to modify its status, and returns the updated conference.
       operationId: UpdateTexmlConference
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135616,7 +135616,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Conferences/{conference_sid}/Participants:
     get:
-      description: Lists conference participants
+      description: Returns the list of participants currently in the specified conference.
       operationId: GetTexmlConferenceParticipants
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135635,7 +135635,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     post:
-      description: Dials a new conference participant
+      description: Dials a new participant into the specified conference and returns the created participant resource.
       operationId: DialTexmlConferenceParticipant
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135662,7 +135662,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Conferences/{conference_sid}/Participants/{call_sid_or_participant_label}:
     delete:
-      description: Deletes a conference participant
+      description: Removes the specified participant from the conference, ending their leg of the call.
       operationId: DeleteTexmlConferenceParticipant
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135678,7 +135678,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     get:
-      description: Gets conference participant resource
+      description: Returns a single conference participant resource by call SID or participant label.
       operationId: GetTexmlConferenceParticipant
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135698,7 +135698,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     post:
-      description: Updates a conference participant
+      description: Updates the specified conference participant, for example muting or holding them, and returns the updated participant.
       operationId: UpdateTexmlConferenceParticipant
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135726,7 +135726,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Conferences/{conference_sid}/Recordings:
     get:
-      description: Lists conference recordings
+      description: Returns the list of recordings made for the specified conference.
       operationId: GetTexmlConferenceRecordings
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135767,7 +135767,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Queues:
     get:
-      description: Lists queue resources.
+      description: Returns a paginated list of queue resources for the account, with support for filtering by creation or update dates.
       operationId: GetTexmlQueues
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135790,7 +135790,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     post:
-      description: Creates a new queue resource.
+      description: Creates a new queue resource for the account with the provided settings and returns it.
       operationId: CreateTexmlQueue
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135816,7 +135816,7 @@ paths:
       x-latency-category: responsive
   /texml/Accounts/{account_sid}/Queues/{queue_sid}:
     delete:
-      description: Delete a queue resource.
+      description: Permanently deletes the specified queue resource from the account.
       operationId: DeleteTexmlQueue
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135831,7 +135831,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     get:
-      description: Returns a queue resource.
+      description: Returns a single queue resource for the account by its QueueSid.
       operationId: GetTexmlQueue
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -135850,7 +135850,7 @@ paths:
       - TeXML REST Commands
       x-latency-category: responsive
     post:
-      description: Updates a queue resource.
+      description: Updates the specified queue resource's settings and returns the updated queue.
       operationId: UpdateTexmlQueue
       parameters:
       - $ref: '#/components/parameters/AccountSid'
@@ -136152,7 +136152,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: interactive
     post:
-      description: Creates a TeXML Application.
+      description: Creates a TeXML application, which defines the voice URLs and settings used to serve TeXML instructions for calls, and returns the created application.
       operationId: CreateTexmlApplication
       parameters: []
       requestBody:
@@ -136188,7 +136188,7 @@ paths:
       x-latency-category: interactive
   /texml_applications/{id}:
     delete:
-      description: Deletes a TeXML Application.
+      description: Permanently deletes the specified TeXML application from your account.
       operationId: DeleteTexmlApplication
       parameters:
       - $ref: '#/components/parameters/id'
@@ -136722,7 +136722,7 @@ paths:
       x-latency-category: responsive
   /traffic/policy/profiles/{id}:
     delete:
-      description: Deletes the traffic policy profile.
+      description: Permanently deletes the specified traffic policy profile from your account.
       operationId: DeleteTrafficPolicyProfile
       parameters:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
@@ -136774,7 +136774,7 @@ paths:
       - Traffic Policy Profiles
       x-latency-category: responsive
     patch:
-      description: Updates a traffic policy profile.
+      description: Updates the specified traffic policy profile and returns the updated profile.
       operationId: UpdateTrafficPolicyProfile
       parameters:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
@@ -137020,7 +137020,7 @@ paths:
       x-latency-category: responsive
   /traffic_policy_profiles/{id}:
     delete:
-      description: Deletes the traffic policy profile.
+      description: Permanently deletes the specified traffic policy profile from your account.
       operationId: DeleteTrafficPolicyProfile
       parameters:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
@@ -137072,7 +137072,7 @@ paths:
       - Traffic Policy Profiles
       x-latency-category: responsive
     patch:
-      description: Updates a traffic policy profile.
+      description: Updates the specified traffic policy profile and returns the updated profile.
       operationId: UpdateTrafficPolicyProfile
       parameters:
       - $ref: '#/components/parameters/TrafficPolicyProfileId'
@@ -137219,7 +137219,7 @@ paths:
       x-latency-category: responsive
   /uac_connections/{id}:
     delete:
-      description: Deletes an existing UAC connection.
+      description: Permanently deletes the specified UAC connection from your account.
       operationId: DeleteUacConnection
       parameters:
       - description: Identifies the resource.
@@ -137698,7 +137698,7 @@ paths:
       x-latency-category: interactive
   /user/addresses:
     get:
-      description: Returns a list of your user addresses.
+      description: Returns a paginated list of your user addresses, with support for filtering and sorting.
       operationId: FindUserAddress
       parameters:
       - $ref: '#/components/parameters/user-addresses_PageConsolidated'
@@ -137730,7 +137730,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     post:
-      description: Creates a user address.
+      description: Creates a new user address from the provided details and returns the created address.
       operationId: CreateUserAddress
       parameters: []
       requestBody:
@@ -137790,7 +137790,7 @@ paths:
       x-latency-category: responsive
   /user_addresses:
     get:
-      description: Returns a list of your user addresses.
+      description: Returns a paginated list of your user addresses, with support for filtering and sorting.
       operationId: FindUserAddress
       parameters:
       - $ref: '#/components/parameters/user-addresses_PageConsolidated'
@@ -137822,7 +137822,7 @@ paths:
       x-endpoint-cost: medium
       x-latency-category: responsive
     post:
-      description: Creates a user address.
+      description: Creates a new user address from the provided details and returns the created address.
       operationId: CreateUserAddress
       parameters: []
       requestBody:
@@ -137882,7 +137882,7 @@ paths:
       x-latency-category: responsive
   /user_tags:
     get:
-      description: List all user tags.
+      description: Returns the user tags defined on your account, with support for filtering. Tags help organize resources such as phone numbers.
       operationId: GetUserTags
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -138075,7 +138075,7 @@ paths:
       - Mobile Voice Connections
       x-latency-category: responsive
     post:
-      description: Create a new mobile voice connection.
+      description: Creates a new mobile voice connection with the provided configuration and returns the created connection.
       operationId: createMobileVoiceConnection
       requestBody:
         content:
@@ -139845,7 +139845,7 @@ paths:
       - Verify
       x-latency-category: responsive
     get:
-      description: Gets a single Verify profile.
+      description: Returns the details of a single Verify profile by its ID, including its verification channel configuration.
       operationId: GetVerifyProfile
       parameters:
       - description: The identifier of the Verify profile to retrieve.
@@ -139941,7 +139941,7 @@ paths:
       x-latency-category: responsive
   /virtual_cross_connects:
     get:
-      description: List all Virtual Cross Connects.
+      description: Returns a paginated list of the virtual cross connects on your account, with support for filtering.
       operationId: ListVirtualCrossConnects
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -140105,7 +140105,7 @@ paths:
       x-latency-category: responsive
   /virtual_cross_connects/{id}:
     delete:
-      description: Delete a Virtual Cross Connect.
+      description: Deletes the specified virtual cross connect from your account.
       operationId: DeleteVirtualCrossConnect
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -140128,7 +140128,7 @@ paths:
       - Virtual Cross Connects
       x-latency-category: responsive
     get:
-      description: Retrieve a Virtual Cross Connect.
+      description: Returns the details of a single virtual cross connect by its identifier.
       operationId: GetVirtualCrossConnect
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -141602,7 +141602,7 @@ paths:
       x-latency-category: responsive
   /whatsapp/message_templates/{id}:
     delete:
-      description: Delete a WhatsApp message template.
+      description: Permanently deletes the specified WhatsApp message template from your account.
       operationId: DeleteWhatsappTemplate
       parameters:
       - $ref: '#/components/parameters/WhatsappTemplateId'
@@ -141952,7 +141952,7 @@ paths:
       x-latency-category: responsive
   /wireguard_interfaces:
     get:
-      description: List all WireGuard Interfaces.
+      description: Returns a paginated list of the WireGuard interfaces on your account, with support for filtering.
       operationId: ListWireguardInterfaces
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -142021,7 +142021,7 @@ paths:
       x-latency-category: responsive
   /wireguard_interfaces/{id}:
     delete:
-      description: Delete a WireGuard Interface.
+      description: Deletes the specified WireGuard interface from its network.
       operationId: DeleteWireguardInterface
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142044,7 +142044,7 @@ paths:
       - WireGuard Interfaces
       x-latency-category: responsive
     get:
-      description: Retrieve a WireGuard Interfaces.
+      description: Returns the details of a single WireGuard interface by its identifier.
       operationId: GetWireguardInterface
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142068,7 +142068,7 @@ paths:
       x-latency-category: responsive
   /wireguard_peers:
     get:
-      description: List all WireGuard peers.
+      description: Returns a paginated list of your WireGuard peers, with support for filtering.
       operationId: ListWireguardPeers
       parameters:
       - description: 'Consolidated filter parameter (deepObject style). Originally:
@@ -142139,7 +142139,7 @@ paths:
       x-latency-category: responsive
   /wireguard_peers/{id}:
     delete:
-      description: Delete the WireGuard peer.
+      description: Deletes the specified WireGuard peer from its interface.
       operationId: DeleteWireguardPeer
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142162,7 +142162,7 @@ paths:
       - WireGuard Interfaces
       x-latency-category: responsive
     get:
-      description: Retrieve the WireGuard peer.
+      description: Returns the details of a single WireGuard peer by its identifier.
       operationId: GetWireguardPeer
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142185,7 +142185,7 @@ paths:
       - WireGuard Interfaces
       x-latency-category: responsive
     patch:
-      description: Update the WireGuard peer.
+      description: Updates the specified WireGuard peer and returns the updated peer.
       operationId: UpdateWireguardPeer
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142311,7 +142311,7 @@ paths:
       x-latency-category: background
   /wireless/detail/records/reports/{id}:
     delete:
-      description: Deletes one specific WDR report.
+      description: Permanently deletes the specified Wireless Detail Record (WDR) report.
       operationId: DeleteWdrReport
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142334,7 +142334,7 @@ paths:
       - Reporting
       x-latency-category: responsive
     get:
-      description: Returns one specific WDR report
+      description: Returns a single Wireless Detail Record (WDR) report by its identifier, including its parameters and current status.
       operationId: GetWdrReport
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142415,7 +142415,7 @@ paths:
       x-latency-category: background
   /wireless/detail_records_reports/{id}:
     delete:
-      description: Deletes one specific WDR report.
+      description: Permanently deletes the specified Wireless Detail Record (WDR) report.
       operationId: DeleteWdrReport
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142438,7 +142438,7 @@ paths:
       - Reporting
       x-latency-category: responsive
     get:
-      description: Returns one specific WDR report
+      description: Returns a single Wireless Detail Record (WDR) report by its identifier, including its parameters and current status.
       operationId: GetWdrReport
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -142662,7 +142662,7 @@ paths:
       x-latency-category: responsive
   /wireless_blocklists/{id}:
     delete:
-      description: Deletes the Wireless Blocklist.
+      description: Permanently deletes the specified wireless blocklist from your account.
       operationId: DeleteWirelessBlocklist
       parameters:
       - $ref: '#/components/parameters/WirelessBlocklistId'
@@ -142708,7 +142708,7 @@ paths:
       - Wireless Blocklists
       x-latency-category: responsive
     patch:
-      description: Update a Wireless Blocklist.
+      description: Updates the specified wireless blocklist. The update is processed asynchronously, so the request is accepted and completes in the background.
       operationId: UpdateWirelessBlocklist
       parameters:
       - $ref: '#/components/parameters/WirelessBlocklistId'

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -93569,7 +93569,7 @@ paths:
       x-latency-category: responsive
   /ai/missions:
     get:
-      description: List all missions for the organization
+      description: Returns a paginated list of all mission definitions in your organization. Missions describe a goal and the tools, knowledge bases, and MCP servers agents may use to accomplish it.
       operationId: get_public_missions_missions
       parameters:
       - description: Page number (1-based)
@@ -93626,7 +93626,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Create a new mission definition
+      description: Creates a new mission definition from the provided configuration and returns the created mission. Execute the mission by starting runs against it.
       operationId: post_public_missions_missions
       requestBody:
         content:
@@ -93669,7 +93669,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/events:
     get:
-      description: List recent events across all missions
+      description: Returns a paginated list of recent events across every mission in your organization, optionally filtered by event type. Useful for building activity feeds or monitoring dashboards.
       operationId: get_public_missions_missions_events
       parameters:
       - description: Filter results by type.
@@ -93734,7 +93734,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/runs:
     get:
-      description: List recent runs across all missions
+      description: Returns a paginated list of recent runs across every mission in your organization, optionally filtered by run status. Useful for monitoring overall mission activity without querying each mission individually.
       operationId: get_public_missions_missions_runs
       parameters:
       - description: Filter results by status.
@@ -93796,7 +93796,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}:
     delete:
-      description: Delete a mission
+      description: Permanently deletes the specified mission definition and returns no content on success.
       operationId: delete_public_missions_missions_mission_id
       parameters:
       - description: Unique identifier of the mission.
@@ -93866,7 +93866,7 @@ paths:
       - Missions
       x-latency-category: responsive
     put:
-      description: Update a mission definition
+      description: Replaces the specified mission's definition with the provided configuration and returns the updated mission.
       operationId: put_public_missions_missions_mission_id
       parameters:
       - description: Unique identifier of the mission.
@@ -93918,7 +93918,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/clone:
     post:
-      description: Clone an existing mission
+      description: Creates a copy of the specified mission as a new mission definition, so you can iterate on its configuration without modifying the original.
       operationId: post_public_missions_missions_mission_id_clone
       parameters:
       - description: Unique identifier of the mission.
@@ -93947,7 +93947,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/knowledge-bases:
     get:
-      description: List all knowledge bases for a mission
+      description: Returns the knowledge bases attached to the specified mission. Knowledge bases provide reference content agents can draw on during runs.
       operationId: get_public_missions_missions_mission_id_knowledge_bases
       parameters:
       - description: Unique identifier of the mission.
@@ -94004,7 +94004,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/knowledge-bases/{knowledge_base_id}:
     delete:
-      description: Delete a knowledge base from a mission
+      description: Detaches the specified knowledge base from the mission so its content is no longer available to agents in subsequent runs.
       operationId: delete_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94041,7 +94041,7 @@ paths:
       - Missions
       x-latency-category: responsive
     get:
-      description: Get a specific knowledge base by ID
+      description: Returns the details of a single knowledge base attached to the specified mission.
       operationId: get_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94076,7 +94076,7 @@ paths:
       - Missions
       x-latency-category: responsive
     put:
-      description: Update a knowledge base definition
+      description: Replaces the definition of the specified knowledge base on this mission.
       operationId: put_public_missions_missions_mission_id_knowledge_bases_knowledge_base_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94112,7 +94112,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/mcp-servers:
     get:
-      description: List all MCP servers for a mission
+      description: Returns the MCP servers configured on the specified mission. MCP servers expose external tools and data sources agents can use during runs.
       operationId: get_public_missions_missions_mission_id_mcp_servers
       parameters:
       - description: Unique identifier of the mission.
@@ -94140,7 +94140,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Create a new MCP server for a mission
+      description: Adds an MCP server to the specified mission, making the server's tools available to agents during runs of this mission.
       operationId: post_public_missions_missions_mission_id_mcp_servers
       parameters:
       - description: Unique identifier of the mission.
@@ -94169,7 +94169,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/mcp-servers/{mcp_server_id}:
     delete:
-      description: Delete an MCP server from a mission
+      description: Removes the specified MCP server from the mission, revoking agent access to its tools in subsequent runs.
       operationId: delete_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94206,7 +94206,7 @@ paths:
       - Missions
       x-latency-category: responsive
     get:
-      description: Get a specific MCP server by ID
+      description: Returns the configuration of a single MCP server attached to the specified mission.
       operationId: get_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94241,7 +94241,7 @@ paths:
       - Missions
       x-latency-category: responsive
     put:
-      description: Update an MCP server definition
+      description: Replaces the configuration of the specified MCP server on this mission.
       operationId: put_public_missions_missions_mission_id_mcp_servers_mcp_server_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94277,7 +94277,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs:
     get:
-      description: List all runs for a specific mission
+      description: Returns a paginated list of runs for the specified mission, optionally filtered by run status, so you can track the mission's execution history over time.
       operationId: get_public_missions_missions_mission_id_runs
       parameters:
       - description: Unique identifier of the mission.
@@ -94346,7 +94346,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Start a new run for a mission
+      description: Starts a new run of the specified mission and returns the created run object. Track its progress through the run detail, plan, and events endpoints.
       operationId: post_public_missions_missions_mission_id_runs
       parameters:
       - description: Unique identifier of the mission.
@@ -94394,7 +94394,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}:
     get:
-      description: Get details of a specific run
+      description: Returns the full details of a single run, including its current status. Use this to poll an in-flight run or inspect the outcome of a completed one.
       operationId: get_public_missions_missions_mission_id_runs_run_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94438,7 +94438,7 @@ paths:
       - Missions
       x-latency-category: responsive
     patch:
-      description: Update run status and/or result
+      description: Updates a run's status and/or result and returns the updated run object. Typically used by executing agents to report progress or record the final outcome.
       operationId: patch_public_missions_missions_mission_id_runs_run_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94494,7 +94494,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/cancel:
     post:
-      description: Cancel a running or paused run
+      description: Cancels a running or paused run and returns the updated run object. A cancelled run stops executing; start a new run to execute the mission again.
       operationId: post_public_missions_missions_mission_id_runs_run_id_cancel
       parameters:
       - description: Unique identifier of the mission.
@@ -94541,7 +94541,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/events:
     get:
-      description: List events for a run (paginated)
+      description: Returns a paginated list of events logged for the specified run, filterable by event type, plan step, and agent, so you can reconstruct exactly what happened during execution.
       operationId: get_public_missions_missions_mission_id_runs_run_id_events
       parameters:
       - description: Unique identifier of the mission.
@@ -94635,7 +94635,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Log an event for a run
+      description: Logs a new event against the specified run and returns the created event. Events form the run's audit trail and can reference a plan step or agent.
       operationId: post_public_missions_missions_mission_id_runs_run_id_events
       parameters:
       - description: Unique identifier of the mission.
@@ -94695,7 +94695,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/events/{event_id}:
     get:
-      description: Get details of a specific event
+      description: Returns the details of a single event logged for the specified run, including its type and payload.
       operationId: get_public_missions_missions_mission_id_runs_run_id_events_event_id
       parameters:
       - description: Unique identifier of the mission.
@@ -94750,7 +94750,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/pause:
     post:
-      description: Pause a running run
+      description: Pauses a currently running run and returns the updated run object. Execution halts until the run is resumed.
       operationId: post_public_missions_missions_mission_id_runs_run_id_pause
       parameters:
       - description: Unique identifier of the mission.
@@ -94795,7 +94795,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/plan:
     get:
-      description: Get the plan (all steps) for a run
+      description: Returns the plan for the specified run, including all plan steps and their statuses, so you can see how the mission was decomposed and how far execution has progressed.
       operationId: get_public_missions_missions_mission_id_runs_run_id_plan
       parameters:
       - description: Unique identifier of the mission.
@@ -94841,7 +94841,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Create the initial plan for a run
+      description: Creates the initial plan for the specified run from the provided steps and returns the created plan steps. Progress is subsequently reported by updating individual steps.
       operationId: post_public_missions_missions_mission_id_runs_run_id_plan
       parameters:
       - description: Unique identifier of the mission.
@@ -94959,7 +94959,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/plan/steps/{step_id}:
     get:
-      description: Get details of a specific plan step
+      description: Returns the details of a single plan step within a run's plan, including its status.
       operationId: get_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
       parameters:
       - description: Unique identifier of the mission.
@@ -95012,7 +95012,7 @@ paths:
       - Missions
       x-latency-category: responsive
     patch:
-      description: Update the status of a plan step
+      description: Updates the status of a single plan step and returns the updated step. Typically called by the executing agent as it works through the plan.
       operationId: patch_public_missions_missions_mission_id_runs_run_id_plan_steps_step_id
       parameters:
       - description: Unique identifier of the mission.
@@ -95074,7 +95074,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/resume:
     post:
-      description: Resume a paused run
+      description: Resumes a previously paused run and returns the updated run object, letting execution continue from where it was paused.
       operationId: post_public_missions_missions_mission_id_runs_run_id_resume
       parameters:
       - description: Unique identifier of the mission.
@@ -95119,7 +95119,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents:
     get:
-      description: List all Telnyx agents linked to a run
+      description: Returns the Telnyx agents currently linked to the specified run. Linked agents participate in executing the run's plan.
       operationId: get_public_missions_missions_mission_id_runs_run_id_telnyx_agents
       parameters:
       - description: Unique identifier of the mission.
@@ -95212,7 +95212,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/runs/{run_id}/telnyx-agents/{telnyx_agent_id}:
     delete:
-      description: Unlink a Telnyx agent from a run
+      description: Unlinks the specified Telnyx agent from the run so it no longer participates in execution. The run itself and its history are unaffected.
       operationId: delete_public_missions_missions_mission_id_runs_run_id_telnyx_agents_telnyx_agent_id
       parameters:
       - description: Unique identifier of the mission.
@@ -95259,7 +95259,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/tools:
     get:
-      description: List all tools for a mission
+      description: Returns the tools configured on the specified mission. Tools define the actions agents may invoke while executing the mission's runs.
       operationId: get_public_missions_missions_mission_id_tools
       parameters:
       - description: Unique identifier of the mission.
@@ -95287,7 +95287,7 @@ paths:
       - Missions
       x-latency-category: responsive
     post:
-      description: Create a new tool for a mission
+      description: Adds a new tool to the specified mission, defining an action agents can invoke during runs of this mission.
       operationId: post_public_missions_missions_mission_id_tools
       parameters:
       - description: Unique identifier of the mission.
@@ -95316,7 +95316,7 @@ paths:
       x-latency-category: responsive
   /ai/missions/{mission_id}/tools/{tool_id}:
     delete:
-      description: Delete a tool from a mission
+      description: Removes the specified tool from the mission so agents can no longer invoke it in subsequent runs.
       operationId: delete_public_missions_missions_mission_id_tools_tool_id
       parameters:
       - description: Unique identifier of the mission.
@@ -95353,7 +95353,7 @@ paths:
       - Missions
       x-latency-category: responsive
     get:
-      description: Get a specific tool by ID
+      description: Returns the definition of a single tool configured on the specified mission.
       operationId: get_public_missions_missions_mission_id_tools_tool_id
       parameters:
       - description: Unique identifier of the mission.
@@ -95388,7 +95388,7 @@ paths:
       - Missions
       x-latency-category: responsive
     put:
-      description: Update a tool definition
+      description: Replaces the definition of the specified tool on this mission.
       operationId: put_public_missions_missions_mission_id_tools_tool_id
       parameters:
       - description: Unique identifier of the mission.
@@ -110231,7 +110231,7 @@ paths:
       x-latency-category: responsive
   /global_ip_allowed_ports:
     get:
-      description: List all Global IP Allowed Ports
+      description: Returns the ports allowed for Global IP traffic, for use when configuring Global IP resources.
       operationId: ListGlobalIpAllowedPorts
       responses:
         '200':
@@ -110314,7 +110314,7 @@ paths:
       x-latency-category: responsive
   /global_ip_assignments:
     get:
-      description: List all Global IP assignments.
+      description: Returns a paginated list of your Global IP assignments, the links between Global IPs and the WireGuard peers that receive their traffic.
       operationId: ListGlobalIpAssignments
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -110341,7 +110341,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     post:
-      description: Create a Global IP assignment.
+      description: Assigns a Global IP to a WireGuard peer so traffic destined for the IP is delivered over that peer's tunnel. Assignment is asynchronous, so the request is accepted and completes in the background.
       operationId: CreateGlobalIpAssignment
       requestBody:
         content:
@@ -110428,7 +110428,7 @@ paths:
       x-latency-category: responsive
   /global_ip_assignments/{id}:
     delete:
-      description: Delete a Global IP assignment.
+      description: Deletes the specified Global IP assignment, detaching the Global IP from its WireGuard peer.
       operationId: DeleteGlobalIpAssignment
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110451,7 +110451,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     get:
-      description: Retrieve a Global IP assignment.
+      description: Returns the details of a single Global IP assignment, including the Global IP and WireGuard peer it links.
       operationId: GetGlobalIpAssignment
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110474,7 +110474,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     patch:
-      description: Update a Global IP assignment.
+      description: Updates the specified Global IP assignment with the provided fields and returns the updated assignment.
       operationId: UpdateGlobalIpAssignment
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110563,7 +110563,7 @@ paths:
       x-latency-category: responsive
   /global_ip_health_check_types:
     get:
-      description: List all Global IP Health check types.
+      description: Returns the health check types available for Global IPs, for use when creating Global IP health checks.
       operationId: ListGlobalIpHealthCheckTypes
       responses:
         '200':
@@ -110587,7 +110587,7 @@ paths:
       x-latency-category: responsive
   /global_ip_health_checks:
     get:
-      description: List all Global IP health checks.
+      description: Returns a paginated list of the Global IP health checks configured on your account.
       operationId: ListGlobalIpHealthChecks
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -110614,7 +110614,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     post:
-      description: Create a Global IP health check.
+      description: Creates a health check for a Global IP to monitor the health of its assignments. Creation is asynchronous, so the request is accepted and the health check becomes active once provisioning completes.
       operationId: CreateGlobalIpHealthCheck
       requestBody:
         content:
@@ -110642,7 +110642,7 @@ paths:
       x-latency-category: responsive
   /global_ip_health_checks/{id}:
     delete:
-      description: Delete a Global IP health check.
+      description: Deletes the specified Global IP health check so it no longer monitors the Global IP's assignments.
       operationId: DeleteGlobalIpHealthCheck
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110665,7 +110665,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     get:
-      description: Retrieve a Global IP health check.
+      description: Returns the details of a single Global IP health check, including its type and configuration.
       operationId: GetGlobalIpHealthCheck
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110736,7 +110736,7 @@ paths:
       x-latency-category: responsive
   /global_ip_protocols:
     get:
-      description: List all Global IP Protocols
+      description: Returns the network protocols supported for Global IP traffic, for use when configuring Global IP resources.
       operationId: ListGlobalIpProtocols
       responses:
         '200':
@@ -110807,7 +110807,7 @@ paths:
       x-latency-category: responsive
   /global_ips:
     get:
-      description: List all Global IPs.
+      description: Returns a paginated list of the Global IPs on your account, including each IP's address and configuration.
       operationId: ListGlobalIps
       parameters:
       - $ref: '#/components/parameters/PageConsolidated'
@@ -110834,7 +110834,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     post:
-      description: Create a Global IP.
+      description: Requests creation of a new Global IP, a static IP address announced from the Telnyx network. Provisioning is asynchronous, so the request is accepted and the Global IP becomes available once provisioning completes.
       operationId: CreateGlobalIp
       requestBody:
         content:
@@ -110862,7 +110862,7 @@ paths:
       x-latency-category: responsive
   /global_ips/{id}:
     delete:
-      description: Delete a Global IP.
+      description: Deletes the specified Global IP and releases its address back to Telnyx.
       operationId: DeleteGlobalIp
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -110885,7 +110885,7 @@ paths:
       - Global IPs
       x-latency-category: responsive
     get:
-      description: Retrieve a Global IP.
+      description: Returns the details of a single Global IP, including its address and current configuration.
       operationId: GetGlobalIp
       parameters:
       - $ref: '#/components/parameters/ResourceId'
@@ -123023,7 +123023,7 @@ paths:
       x-latency-category: responsive
   /porting/events:
     get:
-      description: Returns a list of all porting events.
+      description: Returns a paginated list of porting-related events on your account, such as status changes on porting orders. Supports filtering and is useful for auditing or reconciling webhook deliveries.
       operationId: listPortingEvents
       parameters:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
@@ -123092,7 +123092,7 @@ paths:
       x-latency-category: responsive
   /porting/events/{id}:
     get:
-      description: Show a specific porting event.
+      description: Returns the details of a single porting event, including its type and payload.
       operationId: showPortingEvent
       parameters:
       - description: Identifies the porting event.
@@ -123122,7 +123122,7 @@ paths:
       x-latency-category: responsive
   /porting/events/{id}/republish:
     post:
-      description: Republish a specific porting event.
+      description: Republishes the specified porting event, triggering re-delivery of the corresponding webhook to your account.
       operationId: republishPortingEvent
       parameters:
       - description: Identifies the porting event.
@@ -123145,7 +123145,7 @@ paths:
       x-latency-category: responsive
   /porting/loa_configurations:
     get:
-      description: List the LOA configurations.
+      description: Returns a paginated list of your LOA (Letter of Authorization) configurations. LOA configurations customize the company details and branding used on generated LOA documents.
       operationId: ListLoaConfigurations
       parameters:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
@@ -123172,7 +123172,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     post:
-      description: Create a LOA configuration.
+      description: Creates a new LOA configuration with your company details and branding for use when generating LOA documents for porting orders.
       operationId: CreateLoaConfiguration
       requestBody:
         $ref: '#/components/requestBodies/CreatePortingLOAConfiguration'
@@ -123220,7 +123220,7 @@ paths:
       x-latency-category: responsive
   /porting/loa_configurations/{id}:
     delete:
-      description: Delete a specific LOA configuration.
+      description: Permanently deletes the specified LOA configuration so it can no longer be used when generating LOA documents.
       operationId: DeleteLoaConfiguration
       parameters:
       - description: Identifies a LOA configuration.
@@ -123242,7 +123242,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     get:
-      description: Retrieve a specific LOA configuration.
+      description: Returns the details of a single LOA (Letter of Authorization) configuration by its identifier.
       operationId: GetLoaConfiguration
       parameters:
       - description: Identifies a LOA configuration.
@@ -123271,7 +123271,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     patch:
-      description: Update a specific LOA configuration.
+      description: Updates the specified LOA configuration with the provided fields and returns the updated configuration.
       operationId: UpdateLoaConfiguration
       parameters:
       - description: Identifies a LOA configuration.
@@ -123305,7 +123305,7 @@ paths:
       x-latency-category: responsive
   /porting/loa_configurations/{id}/preview:
     get:
-      description: Preview a specific LOA configuration.
+      description: Renders a preview of the LOA document produced by this configuration so you can verify company details and branding before using it on porting orders.
       operationId: PreviewLoaConfiguration
       parameters:
       - description: Identifies a LOA configuration.
@@ -123407,7 +123407,7 @@ paths:
       x-latency-category: responsive
   /porting/reports/{id}:
     get:
-      description: Retrieve a specific report generated.
+      description: Returns the details of a previously requested porting report, including its status and parameters.
       operationId: GetPortingReport
       parameters:
       - description: Identifies a report.
@@ -123437,7 +123437,7 @@ paths:
       x-latency-category: responsive
   /porting/uk_carriers:
     get:
-      description: List available carriers in the UK.
+      description: Returns the list of UK carriers available for porting, for use when preparing porting orders for UK numbers.
       operationId: listPortingUKCarriers
       responses:
         '200':
@@ -123461,7 +123461,7 @@ paths:
       x-latency-category: responsive
   /porting_orders:
     get:
-      description: Returns a list of your porting order.
+      description: Returns a paginated list of your porting orders. Supports filtering and sorting, and can optionally include the phone numbers attached to each order.
       operationId: ListPortingOrders
       parameters:
       - $ref: '#/components/parameters/porting-order_PageConsolidated'
@@ -123582,7 +123582,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     post:
-      description: Creates a new porting order object.
+      description: Creates a new porting order to bring phone numbers from another carrier to Telnyx. Complete the order's requirements and then confirm it to submit the port.
       operationId: CreatePortingOrder
       requestBody:
         content:
@@ -124002,7 +124002,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{id}/actions/cancel:
     post:
-      description: Cancel a porting order
+      description: Requests cancellation of the porting order and returns the updated order.
       operationId: CancelPortingOrder
       parameters:
       - $ref: '#/components/parameters/PathPortingOrderID'
@@ -124092,7 +124092,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{id}/actions/confirm:
     post:
-      description: Confirm and submit your porting order.
+      description: Confirms the porting order and submits it for processing. Make sure all required information and documents are attached before confirming.
       operationId: ConfirmPortingOrder
       parameters:
       - $ref: '#/components/parameters/PathPortingOrderID'
@@ -124255,7 +124255,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{id}/activation_jobs/{activationJobId}:
     get:
-      description: Returns a porting activation job.
+      description: Returns the details of a single activation job for the porting order, including its current status.
       operationId: GetPortingOrdersActivationJob
       parameters:
       - $ref: '#/components/parameters/PathPortingOrderID'
@@ -124532,7 +124532,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{id}/loa_template:
     get:
-      description: Download a porting order loa template
+      description: Downloads the Letter of Authorization (LOA) template document for this porting order, optionally rendered with a specific LOA configuration.
       operationId: GetPortingOrderLoaTemplate
       parameters:
       - $ref: '#/components/parameters/PathPortingOrderID'
@@ -125093,7 +125093,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     post:
-      description: Creates a new phone number block.
+      description: Creates a phone number block on the porting order, representing a contiguous range of phone numbers to be ported together.
       operationId: createPortingPhoneNumberBlock
       parameters:
       - description: Identifies the Porting Order associated with the phone number
@@ -125126,7 +125126,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{porting_order_id}/phone_number_blocks/{id}:
     delete:
-      description: Deletes a phone number block.
+      description: Deletes the specified phone number block from the porting order.
       operationId: deletePortingPhoneNumberBlock
       parameters:
       - description: Identifies the Porting Order associated with the phone number
@@ -125232,7 +125232,7 @@ paths:
       - Porting Orders
       x-latency-category: responsive
     post:
-      description: Creates a new phone number extension.
+      description: Creates a phone number extension on the porting order, mapping extension ranges to one of the order's phone numbers.
       operationId: createPortingPhoneNumberExtension
       parameters:
       - description: Identifies the Porting Order associated with the phone number
@@ -125265,7 +125265,7 @@ paths:
       x-latency-category: responsive
   /porting_orders/{porting_order_id}/phone_number_extensions/{id}:
     delete:
-      description: Deletes a phone number extension.
+      description: Deletes the specified phone number extension from the porting order.
       operationId: deletePortingPhoneNumberExtension
       parameters:
       - description: Identifies the Porting Order associated with the phone number
@@ -125732,7 +125732,7 @@ paths:
       x-latency-category: responsive
   /portouts/reports/{id}:
     get:
-      description: Retrieve a specific report generated.
+      description: Returns the details of a previously requested port-out report, including its status and parameters.
       operationId: GetPortoutReport
       parameters:
       - description: Identifies a report.

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -107472,7 +107472,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailValidationBatchResponse'
-          description: Batch validation job accepted.
+          description: Batch validation job accepted. Poll GET /email_validations/batch/{id} with the returned batch id to retrieve results.
           headers:
             Idempotent-Replayed:
               $ref: '#/components/headers/IdempotentReplayed'
@@ -109158,7 +109158,7 @@ paths:
                     type: string
                 title: Create Upload request Response
                 type: object
-          description: Successful response
+          description: Upload request accepted. Track progress via GET /external_connections/{id}/uploads/status, or per ticket via GET /external_connections/{id}/uploads/{ticket_id}.
         '401':
           description: Unauthorized
         '404':
@@ -109292,7 +109292,7 @@ paths:
                     $ref: '#/components/schemas/Upload'
                 title: Get Upload Response
                 type: object
-          description: Successful response
+          description: Retry accepted. Track the upload via GET /external_connections/{id}/uploads/{ticket_id}.
         '401':
           description: Unauthorized
         '404':
@@ -109653,7 +109653,7 @@ paths:
                     $ref: '#/components/schemas/Fax'
                 title: Send Fax Response
                 type: object
-          description: Send fax response
+          description: Fax queued for sending. Track its progress by polling GET /faxes/{id} with the returned fax id.
         '422':
           $ref: '#/components/responses/programmable-fax_UnprocessableEntityResponse'
         default:
@@ -110358,7 +110358,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/GlobalIpAssignment'
                 type: object
-          description: Successful response
+          description: Assignment request accepted. Provisioning is asynchronous; poll GET /global_ip_assignments/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -110631,7 +110631,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/GlobalIPHealthCheck'
                 type: object
-          description: Successful response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /global_ip_health_checks/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -110851,7 +110851,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/GlobalIP'
                 type: object
-          description: Successful response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /global_ips/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -121159,7 +121159,7 @@ paths:
                     $ref: '#/components/schemas/PhoneNumberBlocksJob'
                 title: Phone Number Blocks Job Delete Phone Number Block
                 type: object
-          description: Phone number blocks job delete phone numbers requested.
+          description: Block deletion job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -121783,7 +121783,7 @@ paths:
                     $ref: '#/components/schemas/PhoneNumbersJob'
                 title: Phone Numbers Job Delete Phone Numbers
                 type: object
-          description: Phone numbers job delete phone numbers requested.
+          description: Deletion job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -121838,7 +121838,7 @@ paths:
                     $ref: '#/components/schemas/PhoneNumbersJob'
                 title: Phone Numbers Enable Emergency
                 type: object
-          description: Phone numbers enable emergency requested.
+          description: Emergency settings job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -121994,7 +121994,7 @@ paths:
                     $ref: '#/components/schemas/PhoneNumbersJob'
                 title: Phone Numbers Job Update Phone Numbers
                 type: object
-          description: Phone numbers job update phone numbers requested.
+          description: Update job accepted. The response contains a background job; poll GET /phone_numbers/jobs/{id} with the job id until it completes.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -123991,7 +123991,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/PortingOrdersActivationJob'
                 type: object
-          description: Successful response
+          description: Activation request accepted. Track it via GET /porting_orders/{id}/activation_jobs/{activationJobId} using the returned activation job id.
         '401':
           description: Unauthorized
         '422':
@@ -126290,7 +126290,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/PrivateWirelessGateway'
                 type: object
-          description: Successful Response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /private_wireless_gateways/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -126645,7 +126645,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/PublicInternetGatewayRead'
                 type: object
-          description: Successful response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /public_internet_gateways/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -129010,7 +129010,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/RoomComposition'
                 type: object
-          description: Create room composition response.
+          description: Composition request accepted. Poll GET /room_compositions/{room_composition_id} with the returned id until the composition completes.
         '422':
           $ref: '#/components/responses/video_UnprocessableEntity'
       summary: Create a room composition.
@@ -131523,7 +131523,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/BulkSIMCardAction'
                 type: object
-          description: Successful Response
+          description: Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Request bulk disabling voice on SIM cards.
@@ -131573,7 +131573,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/BulkSIMCardAction'
                 type: object
-          description: Successful Response
+          description: Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress.
         '400':
           content:
             application/json:
@@ -131632,7 +131632,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/BulkSIMCardAction'
                 type: object
-          description: Successful Response
+          description: Bulk action accepted. Poll GET /bulk_sim_card_actions/{id} with the returned bulk action id to track progress.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
       summary: Request bulk setting SIM card public IPs.
@@ -131800,7 +131800,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '401':
           description: Unauthorized
         default:
@@ -131831,7 +131831,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '422':
           content:
             application/json:
@@ -131880,7 +131880,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -131925,7 +131925,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '400':
           content:
             application/json:
@@ -131997,7 +131997,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '401':
           description: Unauthorized
         default:
@@ -132034,7 +132034,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '401':
           description: Unauthorized
         default:
@@ -132069,7 +132069,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/wireless_SIMCardAction'
                 type: object
-          description: Successful Response
+          description: Action accepted. The response contains a SIM card action; poll GET /sim_card_actions/{id} with the action id to track progress.
         '401':
           description: Unauthorized
         default:
@@ -134518,7 +134518,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/SubNumberOrdersReport'
                 type: object
-          description: Sub number orders report response
+          description: Report generation accepted. Poll GET /sub_number_orders/report/{report_id} with the returned report id until the report is ready.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -134807,7 +134807,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/SubNumberOrdersReport'
                 type: object
-          description: Sub number orders report response
+          description: Report generation accepted. Poll GET /sub_number_orders_report/{report_id} with the returned report id until the report is ready.
         '400':
           $ref: '#/components/responses/numbers_BadRequestResponse'
         '401':
@@ -142010,7 +142010,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/WireguardInterfaceRead'
                 type: object
-          description: Successful response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /wireguard_interfaces/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -142128,7 +142128,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/WireguardPeer'
                 type: object
-          description: Successful response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /wireguard_peers/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/netapps_UnprocessableEntity'
         default:
@@ -142651,7 +142651,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/WirelessBlocklist'
                 type: object
-          description: Successful Response
+          description: Creation request accepted. Provisioning is asynchronous; poll GET /wireless_blocklists/{id} with the returned id to check status.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:
@@ -142744,7 +142744,7 @@ paths:
                   data:
                     $ref: '#/components/schemas/WirelessBlocklist'
                 type: object
-          description: Successful response
+          description: Update accepted and processed asynchronously. Poll GET /wireless_blocklists/{id} to check the result.
         '422':
           $ref: '#/components/responses/wireless_UnprocessableEntity'
         default:


### PR DESCRIPTION
## Summary

Single PR covering the spec-content fixes for Ora's three usability warnings. Three commits:

1. **75 ops** — description enrichment: Missions (37), Porting Orders (22, incl. the `/portouts/reports/{id}` twin), Global IPs (16)
2. **221 ops** — description enrichment: every remaining sub-40-char stub across 79 tags (TeXML, Conversations/Insights, Notifications, Networks, OAuth clients/grants, WireGuard, SIM cards, connections, legacy reporting twins, and the long tail). **The spec now has zero operations with stub descriptions** (was 296) → addresses `api-schema-analysis` ("partially documented").
3. **31 ops** — 202 Accepted responses now document exactly where to poll for completion (phone-number background jobs → `GET /phone_numbers/jobs/{id}`, SIM card actions → `GET /sim_card_actions/{id}`, bulk actions, Global IP / gateway / WireGuard provisioning, room compositions, porting activation jobs, external-connection uploads, email validation batches, sub-number-order reports, faxes) → addresses `async-job-pattern` ("202s found but no clear polling pattern"). Only operations whose polling GET endpoint provably exists in the spec were touched; descriptions only, no invented headers or schema fields.

All text is grounded in each operation's existing params, schemas, and response codes — no invented enums, payload claims, or endpoints.

## Verification

- 0 sub-40-char operation descriptions remaining spec-wide (was 296)
- 0 description mismatches between `spec3.json` and `spec3.yml` — all 1341 operations and all 62 202-responses checked
- `swagger-parser` full validation passes
- `redocly lint`: 268 errors / 229 warnings — identical counts to `master` (all preexisting)

## Durability caveat

Same as #283: these files are regenerated by the openapi-internal auto-sync; the same content should eventually land in the internal source specs under `prod/external/`. Merging here puts everything live on `telnyx.com/openapi.json` (~5-min cache) immediately.

## After merge

Rescan via `POST https://ora.ai/api/scan/checks` with `checkIds: ["api-schema-analysis","async-job-pattern","function-calling-compat"]`. Note: `function-calling-compat` ("couldn't validate") is a scanner-side failure on the spec's 6.7MB size — the document validates and dereferences cleanly, and no spec edit can fix their analyzer; that one warrants a report via their `POST /api/feedback/check`.