### PR TITLE
docs(openapi): link email batch polling workflow

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -31252,6 +31252,15 @@
               "Idempotent-Replayed": {
                 "$ref": "#/components/headers/IdempotentReplayed"
               }
+            },
+            "links": {
+              "GetBatchJobStatus": {
+                "operationId": "GetEmailValidationBatch",
+                "description": "Poll the accepted batch job until its status is completed or failed.",
+                "parameters": {
+                  "id": "$response.body#/data/id"
+                }
+              }
             }
           },
           "400": {

--- a/openapi/spec3.yml
+++ b/openapi/spec3.yml
@@ -107476,6 +107476,12 @@ paths:
           headers:
             Idempotent-Replayed:
               $ref: '#/components/headers/IdempotentReplayed'
+          links:
+            GetBatchJobStatus:
+              description: Poll the accepted batch job until its status is completed or failed.
+              operationId: GetEmailValidationBatch
+              parameters:
+                id: $response.body#/data/id
         '400':
           content:
             application/json:


### PR DESCRIPTION
## Summary
- add an OpenAPI Link from `POST /email_validations/batch` HTTP 202 to `GetEmailValidationBatch`
- map the polling path parameter from the accepted response body using `$response.body#/data/id`
- keep `spec3.json` and `spec3.yml` synchronized

## Source of truth
This is an explicitly approved exception to mirror the canonical change in team-telnyx/developer-docs-mintlify#1220 for immediate public availability. These files are generated and may be overwritten by a later sync until the canonical PR is published.

No runtime `Location` header is claimed or introduced.

## Validation
- JSON and YAML parse successfully
- link target operation ID exists
- response `data.id` and polling `id` parameter invariants verified
- JSON/YAML link parity verified
- `git diff --check` passes
- Redocly baseline comparison: 0 new findings (existing repository baseline unchanged)
- diff secret-pattern scan passes